### PR TITLE
Switch to travis container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: haskell
+sudo: false
 notifications:
   email: false


### PR DESCRIPTION
This makes the travis-ci folks happy, and makes test runs start faster. I have a patch that tests with several versions of ghc, but until the unit tests pass on one version there is no need to test on four versions.  Especially when each test takes four times as long due to the compiler installs.