### PR TITLE
Parsers based parsers

### DIFF
--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -40,7 +40,8 @@ library
                  , Text.RDF.RDF4H.NTriplesParser
                  , Text.RDF.RDF4H.NTriplesSerializer
                  , Text.RDF.RDF4H.XmlParser
-  build-depends:   base >= 4.8.0.0
+  build-depends:   attoparsec >= 0.13.1.0
+                 , base >= 4.8.0.0
                  , bytestring
                  , directory
                  , containers

--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -55,6 +55,8 @@ library
                  , text-binary
                  , utf8-string
                  , hgal
+                 , parsers
+                 , mtl
   if impl(ghc < 7.6)
     build-depends: ghc-prim
 

--- a/src/Text/RDF/RDF4H/NTriplesParser.hs
+++ b/src/Text/RDF/RDF4H/NTriplesParser.hs
@@ -69,7 +69,7 @@ nt_triple    =
   do
     subj <- nt_subject   <* optional (skipSome nt_space)
     pred <- nt_predicate <* optional (skipSome nt_space)
-    obj  <- nt_object    <* optional (skipSome nt_space) <* (char '.') <* (many nt_space)
+    obj  <- nt_object    <* optional (skipSome nt_space) <* char '.' <* many nt_space
     pure $ Just (Triple subj pred obj)
 -- [6] literal
 nt_literal :: (CharParsing m, Monad m) => m LValue

--- a/src/Text/RDF/RDF4H/NTriplesParser.hs
+++ b/src/Text/RDF/RDF4H/NTriplesParser.hs
@@ -18,6 +18,7 @@ import Control.Monad (void)
 import Text.Parser.Char
 import Text.Parser.Combinators
 import Control.Applicative
+import Data.Maybe (catMaybes)
 
 -- |NTriplesParser is an 'RdfParser' implementation for parsing RDF in the
 -- NTriples format. It requires no configuration options. To use this parser,
@@ -42,12 +43,12 @@ nt_ntripleDoc = manyTill nt_line eof
 
 nt_line :: (CharParsing m, Monad m) => m (Maybe Triple)
 nt_line =
-    skipMany nt_space >>
-     ((nt_comment >>= \res -> pure res)
-      <|> try (nt_triple >>= \res -> nt_eoln *> pure res)
-      <|> try (nt_triple >>= \res -> char '#' *> manyTill anyChar nt_eoln *> pure res)
-      <|> (nt_empty >>= \res -> nt_eoln *> pure res))
-     >>= \res -> pure res
+    skipMany nt_space *>
+     (nt_comment
+      <|> try (nt_triple <* nt_eoln)
+      <|> try (nt_triple <* char '#' <* manyTill anyChar nt_eoln)
+      <|> (nt_empty <* nt_eoln)
+      )
 
 nt_comment :: CharParsing m => m (Maybe Triple)
 nt_comment   = char '#' *> manyTill anyChar nt_eoln *> pure Nothing
@@ -66,27 +67,20 @@ nt_comment   = char '#' *> manyTill anyChar nt_eoln *> pure Nothing
 nt_triple :: (CharParsing m, Monad m) => m (Maybe Triple)
 nt_triple    =
   do
-    subj <- nt_subject
-    optional (skipSome nt_space)
-    pred <- nt_predicate
-    optional (skipSome nt_space)
-    obj <- nt_object
-    optional (skipSome nt_space)
-    void (char '.')
-    void (many nt_space)
+    subj <- nt_subject   <* optional (skipSome nt_space)
+    pred <- nt_predicate <* optional (skipSome nt_space)
+    obj  <- nt_object    <* optional (skipSome nt_space) <* (char '.') <* (many nt_space)
     pure $ Just (Triple subj pred obj)
-
 -- [6] literal
 nt_literal :: (CharParsing m, Monad m) => m LValue
 nt_literal = do
-  s' <- nt_string_literal_quote
-  let s = escapeRDFSyntax s'
+  s <- escapeRDFSyntax <$> nt_string_literal_quote
   option (plainL s) $
                (count 2 (char '^') *> nt_iriref >>= validateURI >>= isAbsoluteParser >>= \iri -> pure (typedL s iri))
-                <|> (nt_langtag >>= \lang -> pure (plainLL s lang))
+                <|> (plainLL s <$> nt_langtag)
 
 -- [9] STRING_LITERAL_QUOTE
-nt_string_literal_quote :: (CharParsing m, Monad m) => m T.Text
+nt_string_literal_quote :: CharParsing m => m T.Text
 nt_string_literal_quote =
     between (char '"') (char '"') $
       T.concat <$> many ((T.singleton <$> noneOf ['\x22','\x5C','\xA','\xD']) <|>
@@ -96,33 +90,28 @@ nt_string_literal_quote =
 -- [144s] LANGTAG
 nt_langtag :: (CharParsing m, Monad m) => m T.Text
 nt_langtag = do
-  void (char '@')
-  ss   <- some (satisfy isLetter)
-  rest <- concat <$> many (char '-' *> some (satisfy isAlphaNum) >>= \lang_str -> pure ('-':lang_str))
+  ss   <- char '@' *> some (satisfy isLetter)
+  rest <- concat <$> many ((:) <$> char '-' <*> some (satisfy isAlphaNum))
   pure (T.pack (ss ++ rest))
 
 -- [8] IRIREF
-nt_iriref ::(CharParsing m, Monad m) => m T.Text
+nt_iriref :: CharParsing m => m T.Text
 nt_iriref =
   between (char '<') (char '>') $
-              T.concat <$> many ( T.singleton <$> noneOf (['\x00'..'\x20'] ++ ['<','>','"','{','}','|','^','`','\\']) <|>
-                                  nt_uchar )
+              T.concat <$> many ( T.singleton <$> noneOf (['\x00'..'\x20'] ++ "<>\"{}|^`\\") <|> nt_uchar )
 
 -- [153s] ECHAR
-nt_echar :: (CharParsing m, Monad m) => m T.Text
-nt_echar = try $ do
-  void (char '\\')
-  c2 <- satisfy isEchar
-  pure (T.pack [c2])
+nt_echar :: CharParsing m => m T.Text
+nt_echar = try $ T.singleton <$> (char '\\' *> satisfy isEchar)
 
 isEchar :: Char -> Bool
 isEchar = (`elem` ['t','b','n','r','f','"','\'','\\'])
 
 -- [10] UCHAR
-nt_uchar :: (CharParsing m, Monad m) => m T.Text
+nt_uchar :: CharParsing m => m T.Text
 nt_uchar =
-    try (char '\\' *> char 'u' *> count 4 hexDigit >>= \cs -> pure $ T.pack ('\\':'u':cs)) <|>
-    try (char '\\' *> char 'U' *> count 8 hexDigit >>= \cs -> pure $ T.pack ('\\':'U':cs))
+    try (T.pack <$> ((++) <$> string "\\u" <*> count 4 hexDigit)) <|>
+    try (T.pack <$> ((++) <$> string "\\U" <*> count 8 hexDigit))
 
 -- nt_empty is a line that isn't a comment or a triple. They appear in the
 -- parsed output as Nothing, whereas a real triple appears as (Just triple).
@@ -133,27 +122,27 @@ nt_empty     = skipMany nt_space *> pure Nothing
 -- blank node.
 nt_subject :: (CharParsing m, Monad m) => m Node
 nt_subject   =
-  fmap unode nt_uriref <|>
-  fmap bnode nt_blank_node_label
+  unode <$> nt_uriref <|>
+  bnode <$> nt_blank_node_label
 
 -- A predicate may only be a URI reference to a resource.
 nt_predicate :: (CharParsing m, Monad m) => m Node
-nt_predicate = fmap unode nt_uriref
+nt_predicate = unode <$> nt_uriref
 
 -- An object may be either a resource (represented by a URI reference),
 -- a blank node (represented by a node id), or an object literal.
 nt_object :: (CharParsing m, Monad m) => m Node
 nt_object =
-  fmap unode nt_uriref <|>
-  fmap bnode nt_blank_node_label <|>
-  fmap LNode nt_literal
+  unode <$> nt_uriref <|>
+  bnode <$> nt_blank_node_label <|>
+  LNode <$> nt_literal
 
 validateUNode :: CharParsing m => T.Text -> m Node
 validateUNode t =
     case unodeValidate t of
-      Nothing        -> unexpected ("Invalid URI in NTriples parser URI validation: " ++ show t)
       Just u@UNode{} -> pure u
       Just node      -> unexpected ("Unexpected node in NTriples parser URI validation: " ++ show node)
+      Nothing        -> unexpected ("Invalid URI in NTriples parser URI validation: " ++ show t)
 
 validateURI :: (CharParsing m, Monad m) => T.Text -> m T.Text
 validateURI t = do
@@ -173,19 +162,15 @@ absoluteURI = isAbsoluteParser
 nt_uriref :: (CharParsing m, Monad m) => m T.Text
 nt_uriref = between (char '<') (char '>') $ do
               unvalidatedUri <- many (satisfy ( /= '>'))
-              t <- validateURI (T.pack unvalidatedUri)
-              absoluteURI t
+              absoluteURI =<< validateURI (T.pack unvalidatedUri)
 
 -- [141s] BLANK_NODE_LABEL
 nt_blank_node_label :: (CharParsing m, Monad m) => m T.Text
 nt_blank_node_label = do
   void (char '_' *> char ':')
   s1 <- nt_pn_chars_u <|> satisfy isDigit
-  s2 <- option "" $ try $ do
-          sub_dots <- many (char '.')
-          sub_s1   <- some nt_pn_chars
-          pure (sub_dots ++ sub_s1)
-  pure (T.pack ("_:" ++ [s1] ++ s2))
+  s2 <- option "" $ try $ (++) <$> many (char '.') <*> some nt_pn_chars
+  pure (T.pack ("_:" ++ s1:s2))
 
 -- [157s] PN_CHARS_BASE
 -- Not used. It used to be. What's happened?
@@ -257,19 +242,16 @@ parseURL' :: (Rdf a) => String -> IO (Either ParseFailure (RDF a))
 parseURL' = _parseURL parseString'
 
 parseFile' :: (Rdf a) => String -> IO (Either ParseFailure (RDF a))
-parseFile' path = fmap (handleParse mkRdf . runParser nt_ntripleDoc () path)
-                   (TIO.readFile path)
+parseFile' path =
+  handleParse mkRdf . runParser nt_ntripleDoc () path
+  <$> TIO.readFile path
 
 handleParse :: {-forall rdf. (RDF rdf) => -} (Triples -> Maybe BaseUrl -> PrefixMappings -> RDF a) ->
                                         Either ParseError [Maybe Triple] ->
                                         Either ParseFailure (RDF a)
 handleParse _mkRdf result
 --  | T.length rem /= 0 = (Left $ ParseFailure $ "Invalid Document. Unparseable end of document: " ++ T.unpack rem)
-  | otherwise          =
-      case result of
+--  | otherwise          =
+  = case result of
         Left err -> Left  $ ParseFailure $ "Parse failure: \n" ++ show err
-        Right ts -> Right $ _mkRdf (conv ts) Nothing (PrefixMappings Map.empty)
-  where
-    conv []            = []
-    conv (Nothing:ts)  = conv ts
-    conv (Just t:ts) = t : conv ts
+        Right ts -> Right $ _mkRdf (catMaybes ts) Nothing (PrefixMappings Map.empty)

--- a/src/Text/RDF/RDF4H/TurtleParser.hs
+++ b/src/Text/RDF/RDF4H/TurtleParser.hs
@@ -694,8 +694,8 @@ no = Nothing
 -- Update the subject and predicate values of the ParseState to Nothing.
 resetSubjectPredicate :: (MonadState ParseState m,CharParsing m) => m ()
 resetSubjectPredicate =
-  get >>= \(bUrl, dUrl, n, pms, _, _, cs, subjC, subjBNodeList, ts,genMap) ->
-  put (bUrl, dUrl, n, pms, [], [], cs, subjC, subjBNodeList, ts,genMap)
+  modify $ \(bUrl, dUrl, n, pms, _, _, cs, subjC, subjBNodeList, ts,genMap) ->
+            (bUrl, dUrl, n, pms, [], [], cs, subjC, subjBNodeList, ts,genMap)
 
 -- Modifies the current parser state by updating any state values among the parameters
 -- that have non-Nothing values.

--- a/src/Text/RDF/RDF4H/TurtleParser.hs
+++ b/src/Text/RDF/RDF4H/TurtleParser.hs
@@ -14,7 +14,7 @@ import Data.Maybe
 import Data.RDF.Types
 import Data.RDF.Namespace
 import Text.RDF.RDF4H.ParserUtils
-import Text.Parsec (runParserT,ParseError)
+import Text.Parsec (runParser,ParseError)
 -- import Text.Parsec.Text (GenParser)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
@@ -758,14 +758,14 @@ parseURL' bUrl docUrl = _parseURL (parseString' bUrl docUrl)
 -- Returns either a @ParseFailure@ or a new RDF containing the parsed triples.
 parseFile' :: (Rdf a) => Maybe BaseUrl -> Maybe T.Text -> String -> IO (Either ParseFailure (RDF a))
 parseFile' bUrl docUrl fpath = do
-  TIO.readFile fpath >>= \bs' -> return $ handleResult bUrl (flip evalState initialState $ runParserT t_turtleDoc () (maybe "" T.unpack docUrl) bs')
+  TIO.readFile fpath >>= \bs' -> return $ handleResult bUrl (runParser (evalStateT t_turtleDoc initialState) () (maybe "" T.unpack docUrl) bs')
   where initialState = (bUrl, docUrl, 1, PrefixMappings Map.empty, [], [], [], [], False, Seq.empty,Map.empty)
 
 -- |Parse the given string as a Turtle document. The arguments and return type have the same semantics
 -- as <parseURL>, except that the last @String@ argument corresponds to the Turtle document itself as
 -- a string rather than a location URI.
 parseString' :: (Rdf a) => Maybe BaseUrl -> Maybe T.Text -> T.Text -> Either ParseFailure (RDF a)
-parseString' bUrl docUrl ttlStr = handleResult bUrl (flip evalState initialState $ runParserT t_turtleDoc () "" ttlStr)
+parseString' bUrl docUrl ttlStr = handleResult bUrl (runParser (evalStateT t_turtleDoc initialState) () "" ttlStr)
   where initialState = (bUrl, docUrl, 1, PrefixMappings Map.empty, [], [], [], [], False, Seq.empty,Map.empty)
 
 handleResult :: Rdf a => Maybe BaseUrl -> Either ParseError (Seq Triple, PrefixMappings) -> Either ParseFailure (RDF a)

--- a/src/Text/RDF/RDF4H/TurtleParser.hs
+++ b/src/Text/RDF/RDF4H/TurtleParser.hs
@@ -7,7 +7,7 @@ module Text.RDF.RDF4H.TurtleParser(
 
 where
 
-import Data.Char (isLetter,isAlphaNum,toLower,isDigit,isHexDigit)
+import Data.Char (isLetter,isAlphaNum,toLower,toUpper,isDigit,isHexDigit)
 import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Maybe
@@ -781,7 +781,7 @@ validateURI t = do
 
 -- Match the lowercase or uppercase form of 'c'
 caseInsensitiveChar :: CharParsing m => Char -> m Char
-caseInsensitiveChar c = satisfy ((==c) . toLower)
+caseInsensitiveChar c = char (toLower c) <|> char (toUpper c)
 
 -- Match the string 's', accepting either lowercase or uppercase form of each character
 caseInsensitiveString :: (CharParsing m, Monad m) => String -> m String

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-5.12
+resolver: lts-7.9
 packages:
 - '.'
 extra-deps:

--- a/testsuite/tests/W3C/Manifest.hs
+++ b/testsuite/tests/W3C/Manifest.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds #-}
 module W3C.Manifest (
   loadManifest,
 
@@ -15,6 +16,8 @@ import Text.RDF.RDF4H.TurtleParser
 import qualified Data.Text as T
 import qualified Data.List as L (find)
 import Data.Maybe (fromJust)
+
+import GHC.Stack
 
 -- | Manifest data as represented in W3C test files.
 data Manifest =
@@ -121,12 +124,12 @@ mfUnrecognizedDatatypes = unode "http://www.w3.org/2001/sw/DataAccess/tests/test
 
 -- | Load the manifest from the given file;
 -- apply the given namespace as the base IRI of the manifest.
-loadManifest :: T.Text -> T.Text -> IO Manifest
+loadManifest :: HasCallStack => T.Text -> T.Text -> IO Manifest
 loadManifest manifestPath baseIRI = do
   parseFile testParser (T.unpack manifestPath) >>= return . rdfToManifest . fromEither
   where testParser = TurtleParser (Just $ BaseUrl baseIRI) Nothing
 
-rdfToManifest :: RDF TList -> Manifest
+rdfToManifest :: HasCallStack => RDF TList -> Manifest
 rdfToManifest rdf = Manifest desc tpls
   where desc = lnodeText $ objectOf $ headDef (error ("query empty: subject mf:node & predicate mf:name in:\n\n" ++ show (triplesOf rdf))) descNode
         -- FIXME: Inconsistent use of nodes for describing the manifest (W3C bug)
@@ -137,10 +140,10 @@ rdfToManifest rdf = Manifest desc tpls
         collectionHead = objectOf $ headDef (error "query: mf:node & mf:entries") $ query rdf (Just manifestNode) (Just mfEntries) Nothing
         manifestNode = headDef (error "manifestSubjectNodes yielding empty list") $ manifestSubjectNodes rdf
 
-rdfToTestEntry :: RDF TList -> Node -> TestEntry
+rdfToTestEntry :: HasCallStack => RDF TList -> Node -> TestEntry
 rdfToTestEntry rdf teSubject = triplesToTestEntry rdf $ query rdf (Just teSubject) Nothing Nothing
 
-triplesToTestEntry :: RDF TList -> Triples -> TestEntry
+triplesToTestEntry :: HasCallStack => RDF TList -> Triples -> TestEntry
 triplesToTestEntry rdf ts =
   case objectByPredicate rdfType ts of
     (UNode "http://www.w3.org/ns/rdftest#TestTurtleEval") -> mkTestTurtleEval ts
@@ -155,7 +158,7 @@ triplesToTestEntry rdf ts =
     (UNode "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax") -> mkTestNTriplesNegativeSyntax ts
     n -> error ("Unknown test case: " ++ show n)
 
-mkTestTurtleEval :: Triples -> TestEntry
+mkTestTurtleEval :: HasCallStack => Triples -> TestEntry
 mkTestTurtleEval ts = TestTurtleEval {
                         name = lnodeText $ objectByPredicate mfName ts,
                         comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -164,7 +167,7 @@ mkTestTurtleEval ts = TestTurtleEval {
                         result = objectByPredicate mfResult ts
                       }
 
-mkTestTurtleNegativeEval :: Triples -> TestEntry
+mkTestTurtleNegativeEval :: HasCallStack => Triples -> TestEntry
 mkTestTurtleNegativeEval ts = TestTurtleNegativeEval {
                                 name = lnodeText $ objectByPredicate mfName ts,
                                 comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -172,7 +175,7 @@ mkTestTurtleNegativeEval ts = TestTurtleNegativeEval {
                                 action = objectByPredicate mfAction ts
                               }
 
-mkTestTurtlePositiveSyntax :: Triples -> TestEntry
+mkTestTurtlePositiveSyntax :: HasCallStack => Triples -> TestEntry
 mkTestTurtlePositiveSyntax ts = TestTurtlePositiveSyntax {
                                   name = lnodeText $ objectByPredicate mfName ts,
                                   comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -180,7 +183,7 @@ mkTestTurtlePositiveSyntax ts = TestTurtlePositiveSyntax {
                                   action = objectByPredicate mfAction ts
                                 }
 
-mkTestTurtleNegativeSyntax :: Triples -> TestEntry
+mkTestTurtleNegativeSyntax :: HasCallStack => Triples -> TestEntry
 mkTestTurtleNegativeSyntax ts = TestTurtleNegativeSyntax {
                                   name = lnodeText $ objectByPredicate mfName ts,
                                   comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -188,7 +191,7 @@ mkTestTurtleNegativeSyntax ts = TestTurtleNegativeSyntax {
                                   action = objectByPredicate mfAction ts
                                 }
 
-mkPositiveEntailmentTest :: Triples -> RDF TList -> TestEntry
+mkPositiveEntailmentTest :: HasCallStack => Triples -> RDF TList -> TestEntry
 mkPositiveEntailmentTest ts rdf = PositiveEntailmentTest {
                                     name = lnodeText $ objectByPredicate mfName ts,
                                     comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -206,7 +209,7 @@ mkPositiveEntailmentTest ts rdf = PositiveEntailmentTest {
           uDT = rdfCollectionToList rdf uDTCollectionHead
           uDTCollectionHead = objectByPredicate mfUnrecognizedDatatypes ts
 
-mkNegativeEntailmentTest :: Triples -> RDF TList -> TestEntry
+mkNegativeEntailmentTest :: HasCallStack => Triples -> RDF TList -> TestEntry
 mkNegativeEntailmentTest ts rdf = NegativeEntailmentTest {
                                     name = lnodeText $ objectByPredicate mfName ts,
                                     comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -224,7 +227,7 @@ mkNegativeEntailmentTest ts rdf = NegativeEntailmentTest {
           uDT = rdfCollectionToList rdf uDTCollectionHead
           uDTCollectionHead = objectByPredicate mfUnrecognizedDatatypes ts
 
-mkTestXMLEval :: Triples -> TestEntry
+mkTestXMLEval :: HasCallStack => Triples -> TestEntry
 mkTestXMLEval ts = TestXMLEval {
                      name = lnodeText $ objectByPredicate mfName ts,
                      comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -235,7 +238,7 @@ mkTestXMLEval ts = TestXMLEval {
                      result = objectByPredicate mfResult ts
                    }
 
-mkTestXMLNegativeSyntax :: Triples -> TestEntry
+mkTestXMLNegativeSyntax :: HasCallStack => Triples -> TestEntry
 mkTestXMLNegativeSyntax ts = TestXMLNegativeSyntax {
                                name = lnodeText $ objectByPredicate mfName ts,
                                comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -245,7 +248,7 @@ mkTestXMLNegativeSyntax ts = TestXMLNegativeSyntax {
                                action = objectByPredicate mfAction ts
                              }
 
-mkTestNTriplesPositiveSyntax :: Triples -> TestEntry
+mkTestNTriplesPositiveSyntax :: HasCallStack => Triples -> TestEntry
 mkTestNTriplesPositiveSyntax ts = TestNTriplesPositiveSyntax {
                                     name = lnodeText $ objectByPredicate mfName ts,
                                     comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -253,7 +256,7 @@ mkTestNTriplesPositiveSyntax ts = TestNTriplesPositiveSyntax {
                                     action = objectByPredicate mfAction ts
                                   }
 
-mkTestNTriplesNegativeSyntax :: Triples -> TestEntry
+mkTestNTriplesNegativeSyntax :: HasCallStack => Triples -> TestEntry
 mkTestNTriplesNegativeSyntax ts = TestNTriplesNegativeSyntax {
                                     name = lnodeText $ objectByPredicate mfName ts,
                                     comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -263,20 +266,20 @@ mkTestNTriplesNegativeSyntax ts = TestNTriplesNegativeSyntax {
 
 -- Filter the triples by given predicate and return the object of the first found triple.
 -- Raises an exception on errors.
-objectByPredicate :: Predicate -> Triples -> Object
+objectByPredicate :: HasCallStack => Predicate -> Triples -> Object
 objectByPredicate p = objectOf . fromJust . L.find (\t -> predicateOf t == p)
 
-manifestSubjectNodes :: RDF TList -> [Subject]
+manifestSubjectNodes :: HasCallStack => RDF TList -> [Subject]
 manifestSubjectNodes rdf = subjectNodes rdf [mfManifest]
 
-subjectNodes :: RDF TList -> [Object] -> [Subject]
+subjectNodes :: HasCallStack => RDF TList -> [Object] -> [Subject]
 subjectNodes rdf = (map subjectOf) . concatMap queryType
   where queryType n = query rdf Nothing (Just rdfType) (Just n)
 
 -- | Text of the literal node.
 -- Note that it doesn't perform type conversion for TypedL.
 -- TODO: Looks useful. Move it to RDF4H lib?
-lnodeText :: Node -> T.Text
+lnodeText :: HasCallStack => Node -> T.Text
 lnodeText (LNode(PlainL t)) = t
 lnodeText (LNode(PlainLL t _)) = t
 lnodeText (LNode(TypedL t _)) = t
@@ -294,15 +297,15 @@ lnodeText _ = error "Not a literal node"
 -- | second argument (`tip`) is the "collection head" (<c1> in the example above),
 -- | (all triples with <rdf:first> and <rdf:rest> pairs).
 -- TODO: Looks useful. Move it to RDF4H lib?
-rdfCollectionToList :: RDF TList -> Node -> [Node]
+rdfCollectionToList :: HasCallStack => RDF TList -> Node -> [Node]
 rdfCollectionToList _ (UNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#nil")) = []
 rdfCollectionToList rdf tip = concatMap (tripleToList rdf) $ nextCollectionTriples rdf tip
 
-tripleToList :: RDF TList -> Triple -> [Node]
+tripleToList :: HasCallStack => RDF TList -> Triple -> [Node]
 tripleToList _ (Triple _ (UNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#first")) n@(UNode _)) = [n]
 tripleToList rdf (Triple _ (UNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#rest")) tip) = rdfCollectionToList rdf tip
-tripleToList _ _ = error "Invalid collection format"
+tripleToList _ trip = error $ "tripleToList: Invalid collection format\n"++show trip
 
-nextCollectionTriples :: RDF TList -> Node -> Triples
+nextCollectionTriples :: HasCallStack => RDF TList -> Node -> Triples
 nextCollectionTriples rdf tip@(BNodeGen _) = query rdf (Just tip) Nothing Nothing
-nextCollectionTriples _ _ = error "Invalid collection format"
+nextCollectionTriples _ node = error $ "nextCollectionTriples: Invalid collection format\n"++show node

--- a/testsuite/tests/W3C/Manifest.hs
+++ b/testsuite/tests/W3C/Manifest.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ConstraintKinds #-}
 module W3C.Manifest (
   loadManifest,
 
@@ -16,8 +15,6 @@ import Text.RDF.RDF4H.TurtleParser
 import qualified Data.Text as T
 import qualified Data.List as L (find)
 import Data.Maybe (fromJust)
-
-import GHC.Stack
 
 -- | Manifest data as represented in W3C test files.
 data Manifest =
@@ -124,12 +121,12 @@ mfUnrecognizedDatatypes = unode "http://www.w3.org/2001/sw/DataAccess/tests/test
 
 -- | Load the manifest from the given file;
 -- apply the given namespace as the base IRI of the manifest.
-loadManifest :: HasCallStack => T.Text -> T.Text -> IO Manifest
+loadManifest :: T.Text -> T.Text -> IO Manifest
 loadManifest manifestPath baseIRI = do
   parseFile testParser (T.unpack manifestPath) >>= return . rdfToManifest . fromEither
   where testParser = TurtleParser (Just $ BaseUrl baseIRI) Nothing
 
-rdfToManifest :: HasCallStack => RDF TList -> Manifest
+rdfToManifest :: RDF TList -> Manifest
 rdfToManifest rdf = Manifest desc tpls
   where desc = lnodeText $ objectOf $ headDef (error ("query empty: subject mf:node & predicate mf:name in:\n\n" ++ show (triplesOf rdf))) descNode
         -- FIXME: Inconsistent use of nodes for describing the manifest (W3C bug)
@@ -140,10 +137,10 @@ rdfToManifest rdf = Manifest desc tpls
         collectionHead = objectOf $ headDef (error "query: mf:node & mf:entries") $ query rdf (Just manifestNode) (Just mfEntries) Nothing
         manifestNode = headDef (error "manifestSubjectNodes yielding empty list") $ manifestSubjectNodes rdf
 
-rdfToTestEntry :: HasCallStack => RDF TList -> Node -> TestEntry
+rdfToTestEntry :: RDF TList -> Node -> TestEntry
 rdfToTestEntry rdf teSubject = triplesToTestEntry rdf $ query rdf (Just teSubject) Nothing Nothing
 
-triplesToTestEntry :: HasCallStack => RDF TList -> Triples -> TestEntry
+triplesToTestEntry :: RDF TList -> Triples -> TestEntry
 triplesToTestEntry rdf ts =
   case objectByPredicate rdfType ts of
     (UNode "http://www.w3.org/ns/rdftest#TestTurtleEval") -> mkTestTurtleEval ts
@@ -158,7 +155,7 @@ triplesToTestEntry rdf ts =
     (UNode "http://www.w3.org/ns/rdftest#TestNTriplesNegativeSyntax") -> mkTestNTriplesNegativeSyntax ts
     n -> error ("Unknown test case: " ++ show n)
 
-mkTestTurtleEval :: HasCallStack => Triples -> TestEntry
+mkTestTurtleEval :: Triples -> TestEntry
 mkTestTurtleEval ts = TestTurtleEval {
                         name = lnodeText $ objectByPredicate mfName ts,
                         comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -167,7 +164,7 @@ mkTestTurtleEval ts = TestTurtleEval {
                         result = objectByPredicate mfResult ts
                       }
 
-mkTestTurtleNegativeEval :: HasCallStack => Triples -> TestEntry
+mkTestTurtleNegativeEval :: Triples -> TestEntry
 mkTestTurtleNegativeEval ts = TestTurtleNegativeEval {
                                 name = lnodeText $ objectByPredicate mfName ts,
                                 comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -175,7 +172,7 @@ mkTestTurtleNegativeEval ts = TestTurtleNegativeEval {
                                 action = objectByPredicate mfAction ts
                               }
 
-mkTestTurtlePositiveSyntax :: HasCallStack => Triples -> TestEntry
+mkTestTurtlePositiveSyntax :: Triples -> TestEntry
 mkTestTurtlePositiveSyntax ts = TestTurtlePositiveSyntax {
                                   name = lnodeText $ objectByPredicate mfName ts,
                                   comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -183,7 +180,7 @@ mkTestTurtlePositiveSyntax ts = TestTurtlePositiveSyntax {
                                   action = objectByPredicate mfAction ts
                                 }
 
-mkTestTurtleNegativeSyntax :: HasCallStack => Triples -> TestEntry
+mkTestTurtleNegativeSyntax :: Triples -> TestEntry
 mkTestTurtleNegativeSyntax ts = TestTurtleNegativeSyntax {
                                   name = lnodeText $ objectByPredicate mfName ts,
                                   comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -191,7 +188,7 @@ mkTestTurtleNegativeSyntax ts = TestTurtleNegativeSyntax {
                                   action = objectByPredicate mfAction ts
                                 }
 
-mkPositiveEntailmentTest :: HasCallStack => Triples -> RDF TList -> TestEntry
+mkPositiveEntailmentTest :: Triples -> RDF TList -> TestEntry
 mkPositiveEntailmentTest ts rdf = PositiveEntailmentTest {
                                     name = lnodeText $ objectByPredicate mfName ts,
                                     comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -209,7 +206,7 @@ mkPositiveEntailmentTest ts rdf = PositiveEntailmentTest {
           uDT = rdfCollectionToList rdf uDTCollectionHead
           uDTCollectionHead = objectByPredicate mfUnrecognizedDatatypes ts
 
-mkNegativeEntailmentTest :: HasCallStack => Triples -> RDF TList -> TestEntry
+mkNegativeEntailmentTest :: Triples -> RDF TList -> TestEntry
 mkNegativeEntailmentTest ts rdf = NegativeEntailmentTest {
                                     name = lnodeText $ objectByPredicate mfName ts,
                                     comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -227,7 +224,7 @@ mkNegativeEntailmentTest ts rdf = NegativeEntailmentTest {
           uDT = rdfCollectionToList rdf uDTCollectionHead
           uDTCollectionHead = objectByPredicate mfUnrecognizedDatatypes ts
 
-mkTestXMLEval :: HasCallStack => Triples -> TestEntry
+mkTestXMLEval :: Triples -> TestEntry
 mkTestXMLEval ts = TestXMLEval {
                      name = lnodeText $ objectByPredicate mfName ts,
                      comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -238,7 +235,7 @@ mkTestXMLEval ts = TestXMLEval {
                      result = objectByPredicate mfResult ts
                    }
 
-mkTestXMLNegativeSyntax :: HasCallStack => Triples -> TestEntry
+mkTestXMLNegativeSyntax :: Triples -> TestEntry
 mkTestXMLNegativeSyntax ts = TestXMLNegativeSyntax {
                                name = lnodeText $ objectByPredicate mfName ts,
                                comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -248,7 +245,7 @@ mkTestXMLNegativeSyntax ts = TestXMLNegativeSyntax {
                                action = objectByPredicate mfAction ts
                              }
 
-mkTestNTriplesPositiveSyntax :: HasCallStack => Triples -> TestEntry
+mkTestNTriplesPositiveSyntax :: Triples -> TestEntry
 mkTestNTriplesPositiveSyntax ts = TestNTriplesPositiveSyntax {
                                     name = lnodeText $ objectByPredicate mfName ts,
                                     comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -256,7 +253,7 @@ mkTestNTriplesPositiveSyntax ts = TestNTriplesPositiveSyntax {
                                     action = objectByPredicate mfAction ts
                                   }
 
-mkTestNTriplesNegativeSyntax :: HasCallStack => Triples -> TestEntry
+mkTestNTriplesNegativeSyntax :: Triples -> TestEntry
 mkTestNTriplesNegativeSyntax ts = TestNTriplesNegativeSyntax {
                                     name = lnodeText $ objectByPredicate mfName ts,
                                     comment = lnodeText $ objectByPredicate rdfsComment ts,
@@ -266,20 +263,20 @@ mkTestNTriplesNegativeSyntax ts = TestNTriplesNegativeSyntax {
 
 -- Filter the triples by given predicate and return the object of the first found triple.
 -- Raises an exception on errors.
-objectByPredicate :: HasCallStack => Predicate -> Triples -> Object
+objectByPredicate :: Predicate -> Triples -> Object
 objectByPredicate p = objectOf . fromJust . L.find (\t -> predicateOf t == p)
 
-manifestSubjectNodes :: HasCallStack => RDF TList -> [Subject]
+manifestSubjectNodes :: RDF TList -> [Subject]
 manifestSubjectNodes rdf = subjectNodes rdf [mfManifest]
 
-subjectNodes :: HasCallStack => RDF TList -> [Object] -> [Subject]
+subjectNodes :: RDF TList -> [Object] -> [Subject]
 subjectNodes rdf = (map subjectOf) . concatMap queryType
   where queryType n = query rdf Nothing (Just rdfType) (Just n)
 
 -- | Text of the literal node.
 -- Note that it doesn't perform type conversion for TypedL.
 -- TODO: Looks useful. Move it to RDF4H lib?
-lnodeText :: HasCallStack => Node -> T.Text
+lnodeText :: Node -> T.Text
 lnodeText (LNode(PlainL t)) = t
 lnodeText (LNode(PlainLL t _)) = t
 lnodeText (LNode(TypedL t _)) = t
@@ -297,15 +294,15 @@ lnodeText _ = error "Not a literal node"
 -- | second argument (`tip`) is the "collection head" (<c1> in the example above),
 -- | (all triples with <rdf:first> and <rdf:rest> pairs).
 -- TODO: Looks useful. Move it to RDF4H lib?
-rdfCollectionToList :: HasCallStack => RDF TList -> Node -> [Node]
+rdfCollectionToList :: RDF TList -> Node -> [Node]
 rdfCollectionToList _ (UNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#nil")) = []
 rdfCollectionToList rdf tip = concatMap (tripleToList rdf) $ nextCollectionTriples rdf tip
 
-tripleToList :: HasCallStack => RDF TList -> Triple -> [Node]
+tripleToList :: RDF TList -> Triple -> [Node]
 tripleToList _ (Triple _ (UNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#first")) n@(UNode _)) = [n]
 tripleToList rdf (Triple _ (UNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#rest")) tip) = rdfCollectionToList rdf tip
-tripleToList _ trip = error $ "tripleToList: Invalid collection format\n"++show trip
+tripleToList _ _ = error "Invalid collection format"
 
-nextCollectionTriples :: HasCallStack => RDF TList -> Node -> Triples
+nextCollectionTriples :: RDF TList -> Node -> Triples
 nextCollectionTriples rdf tip@(BNodeGen _) = query rdf (Just tip) Nothing Nothing
-nextCollectionTriples _ node = error $ "nextCollectionTriples: Invalid collection format\n"++show node
+nextCollectionTriples _ _ = error "Invalid collection format"


### PR DESCRIPTION
I mentioned on reddit that there might be some advantages to using Ed Kmett's parsers package. This PR  replaces all explicit uses of Parsec with the type class CharParsing, and then instantiated with Parsec (and ParsecT over State because ParsecT's MonadState instance is practically useless...).

The advantage of making this change is that it will make changing parser libraries easy in the future - if you want the nice error messages trifecta offers, only the calls to runParser need to be replaced (with some other fairly trivial changes, like changing the error type returned from Parsec's).

I've also put some effort into making the code more idiomatic - avoid monadic functions when functor and applicative will do, make some things shorter, and generally follow most of the suggestions from hlint.

There are still a few places where the code can be made shorter but I think this does a good job improving readability. 