### PR TITLE
Fix running w3c testsuite on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 .*~
 dist
+dist-newstyle
 cabal-dev
 *.o
 *.hi

--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -114,6 +114,7 @@ test-suite test-rdf4h
                , text >= 1.2.1.0
                , directory
                , safe
+               , MissingH
 
   if impl(ghc < 7.6)
     build-depends: ghc-prim

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-7.9
+resolver: lts-8.23
 compiler-check: newer-minor
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
 resolver: lts-7.9
+compiler-check: newer-minor
 packages:
 - '.'
 extra-deps:

--- a/testsuite/tests/Test.hs
+++ b/testsuite/tests/Test.hs
@@ -3,6 +3,7 @@
 module Main where
 
 import Control.Monad
+import Data.List.Utils (replace)
 import qualified Data.Map as Map
 import Data.RDF
 import           Data.RDF.PropertyTests
@@ -53,8 +54,9 @@ main
 -- justification for separation: http://stackoverflow.com/a/33046723
  = do
   dir <- getCurrentDirectory
+  let posix_path = replace "\\" "/" dir
   let fileSchemeUri suitesDir =
-        T.pack ("file://" ++ dir ++ "/" ++ T.unpack suitesDir)
+        T.pack ("file://" ++ posix_path ++ "/" ++ T.unpack suitesDir)
   turtleManifest <-
     loadManifest mfPathTurtle (fileSchemeUri suiteFilesDirTurtle)
   xmlManifest <- loadManifest mfPathXml (fileSchemeUri suiteFilesDirXml)


### PR DESCRIPTION
The default path separator "\" on Windows led to the creation of an incorrect URI.

By the way, the current results of the tests are: `222 out of 1085 tests failed`.