### PR TITLE
Fix tests on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 .*~
-dist
+dist/
+dist-newstyle/
 cabal-dev
 *.o
 *.hi
@@ -18,6 +19,7 @@ countries.ttl
 bench/MainCriterion
 *.tar.gz
 *.zip
+.ghc.environment.*
 
 data/w3c/n3/README
 data/w3c/rdf-mt/LICENSE

--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -40,6 +40,7 @@ library
   build-depends:   attoparsec
                  , base >= 4.8.0.0
                  , bytestring
+                 , filepath
                  , directory
                  , containers
                  , parsec >= 3

--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -101,6 +101,7 @@ test-suite test-rdf4h
                , bytestring
                , containers
                , text >= 1.2.1.0
+               , filepath
                , directory
                , safe
                , network-uri >= 2.6

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
 resolver: lts-7.9
+compiler-check: newer-minor
 packages:
 - '.'
 extra-deps:

--- a/testsuite/tests/Test.hs
+++ b/testsuite/tests/Test.hs
@@ -4,11 +4,13 @@
 module Main where
 
 import Control.Monad
+import Data.Maybe (fromJust)
 import qualified Data.Map as Map
 import Data.RDF
 import           Data.RDF.GraphImplTests
 import           Data.RDF.PropertyTests
 import qualified Data.Text as T
+import System.FilePath ((</>))
 import System.Directory (getCurrentDirectory)
 import Test.QuickCheck.Arbitrary
 import Test.Tasty (defaultMain,testGroup)
@@ -57,7 +59,7 @@ main
  = do
   dir <- getCurrentDirectory
   let fileSchemeUri suitesDir =
-        T.pack ("file://" ++ dir ++ "/" ++ T.unpack suitesDir)
+        fromJust . filePathToUri $ (dir </> T.unpack suitesDir)
   turtleManifest <-
     loadManifest mfPathTurtle (fileSchemeUri suiteFilesDirTurtle)
   xmlManifest <- loadManifest mfPathXml (fileSchemeUri suiteFilesDirXml)


### PR DESCRIPTION
`fileSchemeToFilePath` did not work properly on Windows.

I also added `filePathToUri`. Maybe these two functions would be better in the package `network-uri`:
`URI -> Maybe FilePath` and `FilePath -> Maybe URI`. I'll try to make a pull request there later.