### PR TITLE
Export Data.RDF.Namespace.

### DIFF
--- a/src/Data/RDF.hs
+++ b/src/Data/RDF.hs
@@ -11,6 +11,7 @@ module Data.RDF (
   module Data.RDF.IRI,
   module Data.RDF.Types,
   module Data.RDF.Query,
+  module Data.RDF.Namespace,
 
   -- * RDF type class instances
   module Data.RDF.Graph.TList,


### PR DESCRIPTION
I think `Data.RDF.Namespace` was intended to be exported by `Data.RDF` but wasn't.  This change fixes that.