### PR TITLE
Issue 94: writeUNodeUri adds unnecessary colons

### DIFF
--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -124,6 +124,7 @@ test-suite test-rdf4h
                , filepath
                , directory
                , safe
+               , temporary
 
   if impl(ghc < 7.6)
     build-depends: ghc-prim

--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -125,6 +125,7 @@ test-suite test-rdf4h
                , directory
                , safe
                , temporary
+               , bytestring
 
   if impl(ghc < 7.6)
     build-depends: ghc-prim

--- a/src/Text/RDF/RDF4H/TurtleSerializer.hs
+++ b/src/Text/RDF/RDF4H/TurtleSerializer.hs
@@ -136,7 +136,7 @@ writeUNodeUri :: Handle -> T.Text -> PrefixMappings -> IO ()
 writeUNodeUri h uri pms =
   case mapping of
     Nothing -> hPutChar h '<' >> T.hPutStr h uri >> hPutChar h '>'
-    (Just (pre, localName)) -> T.hPutStr h pre >> hPutChar h ':' >> T.hPutStr h localName
+    (Just (pre, localName)) -> T.hPutStr h pre >> T.hPutStr h localName
   where
     mapping = findMapping pms uri
 

--- a/testsuite/tests/Text/RDF/RDF4H/TurtleSerializerTest.hs
+++ b/testsuite/tests/Text/RDF/RDF4H/TurtleSerializerTest.hs
@@ -2,17 +2,34 @@
 
 module Text.RDF.RDF4H.TurtleSerializerTest (tests) where
 
+import Data.Coerce
+import Data.RDF.Namespace
+import System.IO
+import System.IO.Temp (withSystemTempFile)
 import Test.Tasty
 import Test.Tasty.HUnit
 import Text.RDF.RDF4H.TurtleSerializer
-import Data.RDF.Namespace
-import Data.Coerce
+
+force :: [a] -> ()
+force [] = ()
+force (_:xs) = force xs
 
 tests :: TestTree
-tests =
-  testGroup "findMappings Tests"
-  [ testCase "findMapping correctly finds rdf mapping" $
-    assertEqual "" (Just ("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "subject")) (findMapping (coerce standard_ns_mappings) "rdf:subject")
-  , testCase "findMapping correctly finds rdfs mapping" $
-    assertEqual "" (Just ("http://www.w3.org/2000/01/rdf-schema#", "domain")) (findMapping standard_ns_mappings "rdfs:domain")
+tests = testGroup "Turtle serializer tests"
+  [ testGroup "findMappings Tests"
+    [ testCase "findMapping correctly finds rdf mapping" $
+      assertEqual "" (Just ("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "subject")) (findMapping (coerce standard_ns_mappings) "rdf:subject")
+    , testCase "findMapping correctly finds rdfs mapping" $
+      assertEqual "" (Just ("http://www.w3.org/2000/01/rdf-schema#", "domain")) (findMapping standard_ns_mappings "rdfs:domain")]
+
+  , testGroup "writeUNodeUri tests"
+    [ testCase "should properly serialize a UNode" $
+        withSystemTempFile "rdf4h-"
+          (\_ h -> do
+              hSetBuffering h NoBuffering
+              writeUNodeUri h "rdf:subject" standard_ns_mappings
+              hSeek h AbsoluteSeek 0
+              contents <- hGetContents h
+              seq (force contents) (pure ())
+              "http://www.w3.org/1999/02/22-rdf-syntax-ns#subject" @=? contents)]
   ]

--- a/testsuite/tests/Text/RDF/RDF4H/TurtleSerializerTest.hs
+++ b/testsuite/tests/Text/RDF/RDF4H/TurtleSerializerTest.hs
@@ -3,7 +3,6 @@
 module Text.RDF.RDF4H.TurtleSerializerTest (tests) where
 
 import Data.ByteString as BS
-import Data.Coerce
 import Data.RDF.Namespace
 import System.IO
 import System.IO.Temp (withSystemTempFile)
@@ -15,7 +14,7 @@ tests :: TestTree
 tests = testGroup "Turtle serializer tests"
   [ testGroup "findMappings Tests"
     [ testCase "findMapping correctly finds rdf mapping" $
-      assertEqual "" (Just ("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "subject")) (findMapping (coerce standard_ns_mappings) "rdf:subject")
+      assertEqual "" (Just ("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "subject")) (findMapping standard_ns_mappings "rdf:subject")
     , testCase "findMapping correctly finds rdfs mapping" $
       assertEqual "" (Just ("http://www.w3.org/2000/01/rdf-schema#", "domain")) (findMapping standard_ns_mappings "rdfs:domain")]
 

--- a/testsuite/tests/Text/RDF/RDF4H/TurtleSerializerTest.hs
+++ b/testsuite/tests/Text/RDF/RDF4H/TurtleSerializerTest.hs
@@ -2,6 +2,7 @@
 
 module Text.RDF.RDF4H.TurtleSerializerTest (tests) where
 
+import Data.ByteString as BS
 import Data.Coerce
 import Data.RDF.Namespace
 import System.IO
@@ -9,10 +10,6 @@ import System.IO.Temp (withSystemTempFile)
 import Test.Tasty
 import Test.Tasty.HUnit
 import Text.RDF.RDF4H.TurtleSerializer
-
-force :: [a] -> ()
-force [] = ()
-force (_:xs) = force xs
 
 tests :: TestTree
 tests = testGroup "Turtle serializer tests"
@@ -26,10 +23,8 @@ tests = testGroup "Turtle serializer tests"
     [ testCase "should properly serialize a UNode" $
         withSystemTempFile "rdf4h-"
           (\_ h -> do
-              hSetBuffering h NoBuffering
               writeUNodeUri h "rdf:subject" standard_ns_mappings
               hSeek h AbsoluteSeek 0
-              contents <- hGetContents h
-              seq (force contents) (pure ())
+              contents <- BS.hGetContents h
               "http://www.w3.org/1999/02/22-rdf-syntax-ns#subject" @=? contents)]
   ]


### PR DESCRIPTION
This is the second part of the fix for the issues described in #94 and #27.