### PR TITLE
TurtleSerializer Internal Module

### DIFF
--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -48,6 +48,7 @@ library
                  , Text.RDF.RDF4H.XmlParser
                  , Text.RDF.RDF4H.XmlParser.Identifiers
                  , Text.RDF.RDF4H.ParserUtils
+                 , Text.RDF.RDF4H.TurtleSerializer.Internal
   build-depends:   attoparsec
                  , base >= 4.8.0.0
                  , bytestring

--- a/src/Text/RDF/RDF4H/TurtleSerializer/Internal.hs
+++ b/src/Text/RDF/RDF4H/TurtleSerializer/Internal.hs
@@ -1,0 +1,40 @@
+module Text.RDF.RDF4H.TurtleSerializer.Internal
+  ( findMapping
+  , writeUNodeUri
+  )
+where
+
+import           Data.List (elemIndex)
+import qualified Data.Map as Map
+import           Data.RDF.Namespace hiding (rdf)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import           System.IO
+
+-- Expects a map from uri to prefix, and returns the (prefix, uri_expansion)
+-- from the mappings such that uri_expansion is a prefix of uri, or Nothing if
+-- there is no such mapping. This function does a linear-time search over the
+-- map, but the prefix mappings should always be very small, so it's okay for now.
+findMapping :: PrefixMappings -> T.Text -> Maybe (T.Text, T.Text)
+findMapping (PrefixMappings pms) aliasedURI = do
+  (prefix, target) <- splitAliasedURI aliasedURI
+  uri <- Map.lookup prefix pms
+  pure (uri, target)
+
+writeUNodeUri :: Handle -> T.Text -> PrefixMappings -> IO ()
+writeUNodeUri h uri pms =
+  case mapping of
+    Nothing -> hPutChar h '<' >> T.hPutStr h uri >> hPutChar h '>'
+    (Just (pre, localName)) -> T.hPutStr h pre >> T.hPutStr h localName
+  where
+    mapping = findMapping pms uri
+
+-- |Given an aliased URI (e.g., 'rdf:subject') return a tuple whose first
+-- element is the aliased ('rdf') and whose second part is the path or fragment
+-- ('subject').
+splitAliasedURI :: T.Text -> Maybe (T.Text, T.Text)
+splitAliasedURI uri = do
+  let uriStr = T.unpack uri
+  i <- elemIndex ':' uriStr
+  let (prefix, target) = splitAt i uriStr
+  pure (T.pack prefix, T.pack $ tail target)

--- a/testsuite/tests/Text/RDF/RDF4H/TurtleSerializerTest.hs
+++ b/testsuite/tests/Text/RDF/RDF4H/TurtleSerializerTest.hs
@@ -8,6 +8,7 @@ import Data.RDF.Namespace
 import Data.Function ((&))
 import Data.Map as Map
 import Data.RDF as RDF
+import Text.RDF.RDF4H.TurtleSerializer.Internal
 import System.IO
 import System.IO.Temp (withSystemTempFile)
 import Test.Tasty

--- a/testsuite/tests/Text/RDF/RDF4H/TurtleSerializerTest.hs
+++ b/testsuite/tests/Text/RDF/RDF4H/TurtleSerializerTest.hs
@@ -50,7 +50,6 @@ tests = testGroup "Turtle serializer tests"
           hWriteRdf serializer h g
           hSeek h AbsoluteSeek 0
           actual <- BS.hGetContents h
-          BS.putStrLn actual
           expected @=? actual)
     ]
   ]


### PR DESCRIPTION
Created a new module `Text.RDF.RDF4H.TurtleSerializer.Internal` and moved the functions `findMapping`, 'writeUNodeUri` and `splitAliasedURI` to it so that they could be exposed from it for testing purposes.