### PR TITLE
Turtle quickcheck -- DO NOT MERGE!

### DIFF
--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -105,6 +105,7 @@ test-suite test-rdf4h
   other-modules: Data.RDF.PropertyTests
                  Data.RDF.GraphImplTests
                  Data.RDF.IRITests
+                 Text.RDF.RDF4H.QuickCheck
                  Text.RDF.RDF4H.TurtleSerializerTest
                  Text.RDF.RDF4H.TurtleParser_ConformanceTest
                  Text.RDF.RDF4H.XmlParser_Test

--- a/testsuite/tests/Text/RDF/RDF4H/QuickCheck.hs
+++ b/testsuite/tests/Text/RDF/RDF4H/QuickCheck.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Text.RDF.RDF4H.QuickCheck where
+
+import           Control.Monad
+import qualified Data.Map as Map
+import           Data.RDF hiding (empty)
+import qualified Data.Text as T
+import           Test.QuickCheck
+
+newtype SingletonGraph rdf = SingletonGraph
+  { rdfGraph :: (RDF rdf)
+  }
+
+instance (Rdf rdf) =>
+         Arbitrary (SingletonGraph rdf) where
+  arbitrary = do
+    pref <- arbitraryPrefixMappings
+    baseU' <- arbitraryBaseUrl
+    baseU <- oneof [return (Just baseU'), return Nothing]
+    t <- liftM3 triple arbitraryS arbitraryP arbitraryO
+    return SingletonGraph {rdfGraph = (mkRdf [t] baseU pref)}
+
+instance (Rdf rdf) =>
+         Show (SingletonGraph rdf) where
+  show singletonGraph = showGraph (rdfGraph singletonGraph)
+
+instance Arbitrary BaseUrl where
+  arbitrary = arbitraryBaseUrl
+
+instance Arbitrary PrefixMappings where
+  arbitrary = arbitraryPrefixMappings
+
+arbitraryBaseUrl :: Gen BaseUrl
+arbitraryBaseUrl =
+  oneof $
+  fmap
+    (return . BaseUrl . T.pack)
+    ["http://example.org/", "http://example.com/a", "http://asdf.org/b", "http://asdf.org/c"]
+
+arbitraryPrefixMappings :: Gen PrefixMappings
+arbitraryPrefixMappings =
+  oneof
+    [ return $ PrefixMappings Map.empty
+    , return $
+      PrefixMappings $
+      Map.fromAscList
+        [ (T.pack "ex", T.pack "ex:")
+        , (T.pack "eg1", T.pack "http://example.org/1")
+        , (T.pack "eg2", T.pack "http://example.org/2")
+        , (T.pack "eg3", T.pack "http://example.org/3")
+        ]
+    ]
+
+languages :: [T.Text]
+languages = [T.pack "fr", T.pack "en"]
+
+datatypes :: [T.Text]
+datatypes = fmap (mkUri xsd . T.pack) ["string", "int", "token"]
+
+uris :: [T.Text]
+uris =  [mkUri ex (n <> T.pack (show (i :: Int)))
+        | n <- ["foo", "bar", "quz", "zak"], i <- [0 .. 2]]
+     <> ["ex:" <> n <> T.pack (show (i::Int))
+        | n <- ["s", "p", "o"], i <- [1..3]]
+
+plainliterals :: [LValue]
+plainliterals = [plainLL lit lang | lit <- litvalues, lang <- languages]
+
+typedliterals :: [LValue]
+typedliterals = [typedL lit dtype | lit <- litvalues, dtype <- datatypes]
+
+litvalues :: [T.Text]
+litvalues = fmap T.pack ["hello", "world", "peace", "earth", "", "haskell"]
+
+unodes :: [Node]
+unodes = fmap UNode uris
+
+bnodes :: [ Node]
+bnodes = fmap (BNode . \i -> T.pack ":_genid" <> T.pack (show (i::Int))) [1..5]
+
+lnodes :: [Node]
+lnodes = [LNode lit | lit <- plainliterals <> typedliterals]
+
+-- maximum number of triples
+maxN :: Int
+maxN = 10
+
+instance (Rdf rdf) => Arbitrary (RDF rdf) where
+  arbitrary = do
+    prefix <- arbitraryPrefixMappings
+    baseU' <- arbitraryBaseUrl
+    baseU <- oneof [return (Just baseU'), return Nothing]
+    ts <- arbitraryTs
+    return $ mkRdf ts baseU prefix
+
+instance Arbitrary Triple where
+  arbitrary = do
+    s <- arbitraryS
+    p <- arbitraryP
+    triple s p <$> arbitraryO
+
+instance Arbitrary Node where
+  arbitrary = oneof $ fmap return unodes
+
+arbitraryTs :: Gen Triples
+arbitraryTs = do
+  n <- sized (\_ -> choose (0, maxN))
+  sequence [arbitrary | _ <- [1 .. n]]
+
+arbitraryS, arbitraryP, arbitraryO :: Gen Node
+arbitraryS = oneof $ fmap return $ unodes <> bnodes
+arbitraryP = oneof $ fmap return unodes
+arbitraryO = oneof $ fmap return $ unodes <> bnodes <> lnodes

--- a/testsuite/tests/Text/RDF/RDF4H/TurtleSerializerTest.hs
+++ b/testsuite/tests/Text/RDF/RDF4H/TurtleSerializerTest.hs
@@ -92,17 +92,26 @@ prop_SingleSubject g = withSystemTempFile "rdf4h-"
                                                  ]
         serializer = TurtleSerializer Nothing mappings
 
+        -- Convert a Node to a string if it is a UNode or a BNode. This is
+        -- acceptable since the arbitrary instance for Node's generate only
+        -- those constructors for subjects and that's what this function is
+        -- being used on.
         toUriString :: Node -> Maybe String
         toUriString (UNode uriText) = Just $ T.unpack uriText
         toUriString (BNode bid) = Just $ T.unpack bid
         toUriString _ = Nothing
 
+        -- Convert the subjects for the given graph, g, to Strings.
         subjects :: [String]
         subjects = nub $ sort $ catMaybes $ toUriString <$> subjectOf <$> triplesOf g
 
+        -- Assert that the graph serialization (first parameter) contains
+        -- exactly one instance of the given subject (second parameter).
         assertSingleSubject :: BS.ByteString -> String -> Bool
         assertSingleSubject bs subject = Char8.pack subject `BS.isInfixOf` bs
 
+        -- Assert that each subject in the graph, g, is found in the
+        -- serialization only once.
         assertSingleSubjects :: BS.ByteString -> Bool
         assertSingleSubjects bs = case subjects of
           [] -> True  -- Test should succeed for empty maps


### PR DESCRIPTION
@robstewart57 This work is intended to use QuickCheck to ensure that subject grouping is happening correctly in the Turtle serialization as was discussed in #99.  I've run into an issue and wanted to get some feedback on the technique used.  Basically the approach is naive: serialize a graph to Turtle format and check that the file has only one instance of each subject.  This works for the most part but the QuickCheck tests occasionally fail and it turns out that they fail because the same URI is sometimes used for both subject and predicate, or subject and object.  I think the solution is to update the `RDF TList` `Arbitrary` instance to not use the same URI for more than a given type of node.  Thoughts?