### PR TITLE
Adds common schemas and schema->Haskell module generation

### DIFF
--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -9,8 +9,8 @@ description:
   selecting triples that satisfy an arbitrary predicate function. It
   also supports IRI parsing and resolution.
 
-author:          Rob Stewart, Pierre Le Marre, Slava Kravchenko, Calvin Smith
-copyright:       (c) Rob Stewart, Pierre Le Marre, Slava Kravchenko, Calvin Smith, Renzo Carbonara
+author:          Rob Stewart, Pierre Le Marre, Slava Kravchenko, Calvin Smith,  Fabian Meyer
+copyright:       (c) Rob Stewart, Pierre Le Marre, Slava Kravchenko, Calvin Smith, Renzo Carbonara, Fabian Meyer
 maintainer:      Rob Stewart <robstewart57@gmail.com>
 homepage:        https://github.com/robstewart57/rdf4h
 bug-reports:     https://github.com/robstewart57/rdf4h/issues
@@ -42,6 +42,14 @@ library
                  , Data.RDF.Graph.AdjHashMap
                  , Data.RDF.Graph.AlgebraicGraph
                  , Data.RDF.Graph.TList
+                 , Data.RDF.Vocabulary.Generator.VocabularyGenerator
+                 , Data.RDF.Vocabulary.DCTerms
+                 , Data.RDF.Vocabulary.OWL
+                 , Data.RDF.Vocabulary.RDF
+                 , Data.RDF.Vocabulary.XSD
+                 , Data.RDF.Vocabulary.VANN
+                 , Data.RDF.Vocabulary.SHACL
+                 , Data.RDF.Vocabulary.RDFS
                  , Text.RDF.RDF4H.TurtleParser
                  , Text.RDF.RDF4H.TurtleSerializer
                  , Text.RDF.RDF4H.NTriplesParser
@@ -76,7 +84,9 @@ library
                  , selective
                  , html-entities
                  , xeno
+                 , template-haskell
   other-modules:   Text.RDF.RDF4H.XmlParser.Xmlbf
+                 , Text.RDF.RDF4H.XmlParser.Xeno
                  , Text.RDF.RDF4H.XmlParser.Xeno
   if impl(ghc < 7.6)
     build-depends: ghc-prim

--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -25,6 +25,15 @@ extra-tmp-files: test
 extra-source-files: examples/ParseURLs.hs
                   , examples/ESWC.hs
                   , examples/BuildRDFGraph.hs
+                  , resources/dcterms.ttl
+                  , resources/foaf.ttl
+                  , resources/skos.ttl
+                  , resources/owl.ttl
+                  , resources/rdfs.ttl
+                  , resources/rdf.ttl
+                  , resources/shacl.ttl
+                  , resources/vann.ttl
+                  , resources/xsd.ttl
 
 source-repository head
   type:     git
@@ -50,6 +59,8 @@ library
                  , Data.RDF.Vocabulary.VANN
                  , Data.RDF.Vocabulary.SHACL
                  , Data.RDF.Vocabulary.RDFS
+                 , Data.RDF.Vocabulary.FOAF
+                 , Data.RDF.Vocabulary.SKOS
                  , Text.RDF.RDF4H.TurtleParser
                  , Text.RDF.RDF4H.TurtleSerializer
                  , Text.RDF.RDF4H.NTriplesParser

--- a/resources/dcterms.ttl
+++ b/resources/dcterms.ttl
@@ -1,0 +1,1037 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcam: <http://purl.org/dc/dcam/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://purl.org/dc/terms/>
+    dcterms:modified "2012-06-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:publisher <http://purl.org/dc/aboutdcmi#DCMI> ;
+    <http://purl.org/vocab/vann/preferredNamespaceUri> "http://purl.org/dc/terms/";
+    dcterms:title "DCMI Metadata Terms - other"@en .
+
+dcterms:Agent
+    dcterms:description "Examples of Agent include person, organization, and software agent."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#Agent-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a dcterms:AgentClass, rdfs:Class ;
+    rdfs:comment "A resource that acts or has the power to act."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Agent"@en .
+
+dcterms:AgentClass
+    dcterms:description "Examples of Agent Class include groups seen as classes, such as students, women, charities, lecturers."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#AgentClass-003> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2012-06-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A group of agents."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Agent Class"@en ;
+    rdfs:subClassOf rdfs:Class .
+
+dcterms:BibliographicResource
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#BibliographicResource-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A book, article, or other documentary resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Bibliographic Resource"@en .
+
+dcterms:Box
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#Box-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Datatype ;
+    rdfs:comment "The set of regions in space defined by their geographic coordinates according to the DCMI Box Encoding Scheme."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "DCMI Box"@en ;
+    rdfs:seeAlso <http://dublincore.org/documents/dcmi-box/> .
+
+dcterms:DCMIType
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#DCMIType-005> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2012-06-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a dcam:VocabularyEncodingScheme ;
+    rdfs:comment "The set of classes specified by the DCMI Type Vocabulary, used to categorize the nature or genre of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "DCMI Type Vocabulary"@en ;
+    rdfs:seeAlso <http://purl.org/dc/dcmitype/> .
+
+dcterms:DDC
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#DDC-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a dcam:VocabularyEncodingScheme ;
+    rdfs:comment "The set of conceptual resources specified by the Dewey Decimal Classification."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "DDC"@en ;
+    rdfs:seeAlso <http://www.oclc.org/dewey/> .
+
+dcterms:FileFormat
+    dcterms:description "Examples include the formats defined by the list of Internet Media Types."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#FileFormat-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A digital resource format."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "File Format"@en ;
+    rdfs:subClassOf dcterms:MediaType .
+
+dcterms:Frequency
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#Frequency-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A rate at which something recurs."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Frequency"@en .
+
+dcterms:IMT
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#IMT-004> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a dcam:VocabularyEncodingScheme ;
+    rdfs:comment "The set of media types specified by the Internet Assigned Numbers Authority."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "IMT"@en ;
+    rdfs:seeAlso <http://www.iana.org/assignments/media-types/> .
+
+dcterms:ISO3166
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#ISO3166-004> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Datatype ;
+    rdfs:comment "The set of codes listed in ISO 3166-1 for the representation of names of countries."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "ISO 3166"@en ;
+    rdfs:seeAlso <http://www.iso.org/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html> .
+
+dcterms:ISO639-2
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#ISO639-2-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Datatype ;
+    rdfs:comment "The three-letter alphabetic codes listed in ISO639-2 for the representation of names of languages."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "ISO 639-2"@en ;
+    rdfs:seeAlso <http://lcweb.loc.gov/standards/iso639-2/langhome.html> .
+
+dcterms:ISO639-3
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#ISO639-3-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Datatype ;
+    rdfs:comment "The set of three-letter codes listed in ISO 639-3 for the representation of names of languages."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "ISO 639-3"@en ;
+    rdfs:seeAlso <http://www.sil.org/iso639-3/> .
+
+dcterms:Jurisdiction
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#Jurisdiction-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "The extent or range of judicial, law enforcement, or other authority."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Jurisdiction"@en ;
+    rdfs:subClassOf dcterms:LocationPeriodOrJurisdiction .
+
+dcterms:LCC
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#LCC-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a dcam:VocabularyEncodingScheme ;
+    rdfs:comment "The set of conceptual resources specified by the Library of Congress Classification."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "LCC"@en ;
+    rdfs:seeAlso <http://lcweb.loc.gov/catdir/cpso/lcco/lcco.html> .
+
+dcterms:LCSH
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#LCSH-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a dcam:VocabularyEncodingScheme ;
+    rdfs:comment "The set of labeled concepts specified by the Library of Congress Subject Headings."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "LCSH"@en .
+
+dcterms:LicenseDocument
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#LicenseDocument-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A legal document giving official permission to do something with a Resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "License Document"@en ;
+    rdfs:subClassOf dcterms:RightsStatement .
+
+dcterms:LinguisticSystem
+    dcterms:description "Examples include written, spoken, sign, and computer languages."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#LinguisticSystem-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A system of signs, symbols, sounds, gestures, or rules used in communication."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Linguistic System"@en .
+
+dcterms:Location
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#Location-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A spatial region or named place."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Location"@en ;
+    rdfs:subClassOf dcterms:LocationPeriodOrJurisdiction .
+
+dcterms:LocationPeriodOrJurisdiction
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#LocationPeriodOrJurisdiction-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A location, period of time, or jurisdiction."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Location, Period, or Jurisdiction"@en .
+
+dcterms:MESH
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#MESH-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a dcam:VocabularyEncodingScheme ;
+    rdfs:comment "The set of labeled concepts specified by the Medical Subject Headings."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "MeSH"@en ;
+    rdfs:seeAlso <http://www.nlm.nih.gov/mesh/meshhome.html> .
+
+dcterms:MediaType
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#MediaType-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A file format or physical medium."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Media Type"@en ;
+    rdfs:subClassOf dcterms:MediaTypeOrExtent .
+
+dcterms:MediaTypeOrExtent
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#MediaTypeOrExtent-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A media type or extent."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Media Type or Extent"@en .
+
+dcterms:MethodOfAccrual
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#MethodOfAccrual-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A method by which resources are added to a collection."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Method of Accrual"@en .
+
+dcterms:MethodOfInstruction
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#MethodOfInstruction-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A process that is used to engender knowledge, attitudes, and skills."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Method of Instruction"@en .
+
+dcterms:NLM
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#NLM-002> ;
+    dcterms:issued "2005-06-13"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a dcam:VocabularyEncodingScheme ;
+    rdfs:comment "The set of conceptual resources specified by the National Library of Medicine Classification."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "NLM"@en ;
+    rdfs:seeAlso <http://wwwcf.nlm.nih.gov/class/> .
+
+dcterms:Period
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#Period-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Datatype ;
+    rdfs:comment "The set of time intervals defined by their limits according to the DCMI Period Encoding Scheme."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "DCMI Period"@en ;
+    rdfs:seeAlso <http://dublincore.org/documents/dcmi-period/> .
+
+dcterms:PeriodOfTime
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#PeriodOfTime-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "An interval of time that is named or defined by its start and end dates."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Period of Time"@en ;
+    rdfs:subClassOf dcterms:LocationPeriodOrJurisdiction .
+
+dcterms:PhysicalMedium
+    dcterms:description "Examples include paper, canvas, or DVD."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#PhysicalMedium-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A physical material or carrier."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Physical Medium"@en ;
+    rdfs:subClassOf dcterms:MediaType .
+
+dcterms:PhysicalResource
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#PhysicalResource-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A material thing."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Physical Resource"@en .
+
+dcterms:Point
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#Point-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Datatype ;
+    rdfs:comment "The set of points in space defined by their geographic coordinates according to the DCMI Point Encoding Scheme."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "DCMI Point"@en ;
+    rdfs:seeAlso <http://dublincore.org/documents/dcmi-point/> .
+
+dcterms:Policy
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#Policy-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A plan or course of action by an authority, intended to influence and determine decisions, actions, and other matters."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Policy"@en .
+
+dcterms:ProvenanceStatement
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#ProvenanceStatement-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A statement of any changes in ownership and custody of a resource since its creation that are significant for its authenticity, integrity, and interpretation."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Provenance Statement"@en .
+
+dcterms:RFC1766
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#RFC1766-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Datatype ;
+    rdfs:comment "The set of tags, constructed according to RFC 1766, for the identification of languages."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "RFC 1766"@en ;
+    rdfs:seeAlso <http://www.ietf.org/rfc/rfc1766.txt> .
+
+dcterms:RFC3066
+    dcterms:description "RFC 3066 has been obsoleted by RFC 4646."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#RFC3066-002> ;
+    dcterms:issued "2002-07-13"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Datatype ;
+    rdfs:comment "The set of tags constructed according to RFC 3066 for the identification of languages."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "RFC 3066"@en ;
+    rdfs:seeAlso <http://www.ietf.org/rfc/rfc3066.txt> .
+
+dcterms:RFC4646
+    dcterms:description "RFC 4646 obsoletes RFC 3066."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#RFC4646-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Datatype ;
+    rdfs:comment "The set of tags constructed according to RFC 4646 for the identification of languages."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "RFC 4646"@en ;
+    rdfs:seeAlso <http://www.ietf.org/rfc/rfc4646.txt> .
+
+dcterms:RFC5646
+    dcterms:description "RFC 5646 obsoletes RFC 4646."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#RFC5646-001> ;
+    dcterms:issued "2010-10-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Datatype ;
+    rdfs:comment "The set of tags constructed according to RFC 5646 for the identification of languages."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "RFC 5646"@en ;
+    rdfs:seeAlso <http://www.ietf.org/rfc/rfc5646.txt> .
+
+dcterms:RightsStatement
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#RightsStatement-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Rights Statement"@en .
+
+dcterms:SizeOrDuration
+    dcterms:description "Examples include a number of pages, a specification of length, width, and breadth, or a period in hours, minutes, and seconds."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#SizeOrDuration-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A dimension or extent, or a time taken to play or execute."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Size or Duration"@en ;
+    rdfs:subClassOf dcterms:MediaTypeOrExtent .
+
+dcterms:Standard
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#Standard-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A basis for comparison; a reference point against which other things can be evaluated."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Standard"@en .
+
+dcterms:TGN
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#TGN-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a dcam:VocabularyEncodingScheme ;
+    rdfs:comment "The set of places specified by the Getty Thesaurus of Geographic Names."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "TGN"@en ;
+    rdfs:seeAlso <http://www.getty.edu/research/tools/vocabulary/tgn/index.html> .
+
+dcterms:UDC
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#UDC-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a dcam:VocabularyEncodingScheme ;
+    rdfs:comment "The set of conceptual resources specified by the Universal Decimal Classification."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "UDC"@en ;
+    rdfs:seeAlso <http://www.udcc.org/> .
+
+dcterms:URI
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#URI-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Datatype ;
+    rdfs:comment "The set of identifiers constructed according to the generic syntax for Uniform Resource Identifiers as specified by the Internet Engineering Task Force."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "URI"@en ;
+    rdfs:seeAlso <http://www.ietf.org/rfc/rfc3986.txt> .
+
+dcterms:W3CDTF
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#W3CDTF-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Datatype ;
+    rdfs:comment "The set of dates and times constructed according to the W3C Date and Time Formats Specification."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "W3C-DTF"@en ;
+    rdfs:seeAlso <http://www.w3.org/TR/NOTE-datetime> .
+
+dcterms:abstract
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#abstract-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A summary of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Abstract"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/description>, dcterms:description .
+
+dcterms:accessRights
+    dcterms:description "Access Rights may include information regarding access or restrictions based on privacy, security, or other policies."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#accessRights-002> ;
+    dcterms:issued "2003-02-15"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "Information about who can access the resource or an indication of its security status."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Access Rights"@en ;
+    rdfs:range dcterms:RightsStatement ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/rights>, dcterms:rights .
+
+dcterms:accrualMethod
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#accrualMethod-003> ;
+    dcterms:issued "2005-06-13"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2010-10-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "The method by which items are added to a collection."@en ;
+    rdfs:domain <http://purl.org/dc/dcmitype/Collection> ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Accrual Method"@en ;
+    rdfs:range dcterms:MethodOfAccrual .
+
+dcterms:accrualPeriodicity
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#accrualPeriodicity-003> ;
+    dcterms:issued "2005-06-13"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2010-10-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "The frequency with which items are added to a collection."@en ;
+    rdfs:domain <http://purl.org/dc/dcmitype/Collection> ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Accrual Periodicity"@en ;
+    rdfs:range dcterms:Frequency .
+
+dcterms:accrualPolicy
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#accrualPolicy-003> ;
+    dcterms:issued "2005-06-13"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2010-10-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "The policy governing the addition of items to a collection."@en ;
+    rdfs:domain <http://purl.org/dc/dcmitype/Collection> ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Accrual Policy"@en ;
+    rdfs:range dcterms:Policy .
+
+dcterms:alternative
+    dcterms:description "The distinction between titles and alternative titles is application-specific."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#alternative-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2010-10-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "An alternative name for the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Alternative Title"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/title>, dcterms:title .
+
+dcterms:audience
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#audience-003> ;
+    dcterms:issued "2001-05-21"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A class of entity for whom the resource is intended or useful."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Audience"@en ;
+    rdfs:range dcterms:AgentClass .
+
+dcterms:available
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#available-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "Date (often a range) that the resource became or will become available."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Date Available"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/date>, dcterms:date .
+
+dcterms:bibliographicCitation
+    dcterms:description "Recommended practice is to include sufficient bibliographic detail to identify the resource as unambiguously as possible."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#bibliographicCitation-002> ;
+    dcterms:issued "2003-02-15"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A bibliographic reference for the resource."@en ;
+    rdfs:domain dcterms:BibliographicResource ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Bibliographic Citation"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/identifier>, dcterms:identifier .
+
+dcterms:conformsTo
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#conformsTo-003> ;
+    dcterms:issued "2001-05-21"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "An established standard to which the described resource conforms."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Conforms To"@en ;
+    rdfs:range dcterms:Standard ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation .
+
+dcterms:contributor
+    dcterms:description "Examples of a Contributor include a person, an organization, or a service."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#contributorT-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2010-10-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "An entity responsible for making contributions to the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Contributor"@en ;
+    rdfs:range dcterms:Agent ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/contributor> .
+
+dcterms:coverage
+    dcterms:description "Spatial topic and spatial applicability may be a named place or a location specified by its geographic coordinates. Temporal topic may be a named period, date, or date range. A jurisdiction may be a named administrative entity or a geographic place to which the resource applies. Recommended best practice is to use a controlled vocabulary such as the Thesaurus of Geographic Names [TGN]. Where appropriate, named places or time periods can be used in preference to numeric identifiers such as sets of coordinates or date ranges."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#coverageT-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "The spatial or temporal topic of the resource, the spatial applicability of the resource, or the jurisdiction under which the resource is relevant."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Coverage"@en ;
+    rdfs:range dcterms:LocationPeriodOrJurisdiction ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/coverage> .
+
+dcterms:created
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#created-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "Date of creation of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Date Created"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/date>, dcterms:date .
+
+dcterms:creator
+    dcterms:description "Examples of a Creator include a person, an organization, or a service."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#creatorT-002> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2010-10-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "An entity primarily responsible for making the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Creator"@en ;
+    rdfs:range dcterms:Agent ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/creator>, dcterms:contributor ;
+    owl:equivalentProperty <http://xmlns.com/foaf/0.1/maker> .
+
+dcterms:date
+    dcterms:description "Date may be used to express temporal information at any level of granularity.  Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#dateT-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A point or period of time associated with an event in the lifecycle of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Date"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/date> .
+
+dcterms:dateAccepted
+    dcterms:description "Examples of resources to which a Date Accepted may be relevant are a thesis (accepted by a university department) or an article (accepted by a journal)."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#dateAccepted-002> ;
+    dcterms:issued "2002-07-13"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "Date of acceptance of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Date Accepted"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/date>, dcterms:date .
+
+dcterms:dateCopyrighted
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#dateCopyrighted-002> ;
+    dcterms:issued "2002-07-13"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "Date of copyright."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Date Copyrighted"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/date>, dcterms:date .
+
+dcterms:dateSubmitted
+    dcterms:description "Examples of resources to which a Date Submitted may be relevant are a thesis (submitted to a university department) or an article (submitted to a journal)."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#dateSubmitted-002> ;
+    dcterms:issued "2002-07-13"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "Date of submission of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Date Submitted"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/date>, dcterms:date .
+
+dcterms:description
+    dcterms:description "Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#descriptionT-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "An account of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Description"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/description> .
+
+dcterms:educationLevel
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#educationLevel-002> ;
+    dcterms:issued "2002-07-13"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A class of entity, defined in terms of progression through an educational or training context, for which the described resource is intended."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Audience Education Level"@en ;
+    rdfs:range dcterms:AgentClass ;
+    rdfs:subPropertyOf dcterms:audience .
+
+dcterms:extent
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#extent-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "The size or duration of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Extent"@en ;
+    rdfs:range dcterms:SizeOrDuration ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/format>, dcterms:format .
+
+dcterms:format
+    dcterms:description "Examples of dimensions include size and duration. Recommended best practice is to use a controlled vocabulary such as the list of Internet Media Types [MIME]."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#formatT-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "The file format, physical medium, or dimensions of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Format"@en ;
+    rdfs:range dcterms:MediaTypeOrExtent ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/format> .
+
+dcterms:hasFormat
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#hasFormat-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource that is substantially the same as the pre-existing described resource, but in another format."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Has Format"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:hasPart
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#hasPart-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource that is included either physically or logically in the described resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Has Part"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:hasVersion
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#hasVersion-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource that is a version, edition, or adaptation of the described resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Has Version"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:identifier
+    dcterms:description "Recommended best practice is to identify the resource by means of a string conforming to a formal identification system. "@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#identifierT-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "An unambiguous reference to the resource within a given context."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Identifier"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/identifier> .
+
+dcterms:instructionalMethod
+    dcterms:description "Instructional Method will typically include ways of presenting instructional materials or conducting instructional activities, patterns of learner-to-learner and learner-to-instructor interactions, and mechanisms by which group and individual levels of learning are measured.  Instructional methods include all aspects of the instruction and learning processes from planning and implementation through evaluation and feedback."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#instructionalMethod-002> ;
+    dcterms:issued "2005-06-13"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A process, used to engender knowledge, attitudes and skills, that the described resource is designed to support."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Instructional Method"@en ;
+    rdfs:range dcterms:MethodOfInstruction .
+
+dcterms:isFormatOf
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#isFormatOf-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource that is substantially the same as the described resource, but in another format."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Is Format Of"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:isPartOf
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#isPartOf-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource in which the described resource is physically or logically included."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Is Part Of"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:isReferencedBy
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#isReferencedBy-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource that references, cites, or otherwise points to the described resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Is Referenced By"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:isReplacedBy
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#isReplacedBy-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource that supplants, displaces, or supersedes the described resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Is Replaced By"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:isRequiredBy
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#isRequiredBy-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource that requires the described resource to support its function, delivery, or coherence."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Is Required By"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:isVersionOf
+    dcterms:description "Changes in version imply substantive changes in content rather than differences in format."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#isVersionOf-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource of which the described resource is a version, edition, or adaptation."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Is Version Of"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:issued
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#issued-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "Date of formal issuance (e.g., publication) of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Date Issued"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/date>, dcterms:date .
+
+dcterms:language
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as RFC 4646 [RFC4646]."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#languageT-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A language of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Language"@en ;
+    rdfs:range dcterms:LinguisticSystem ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/language> .
+
+dcterms:license
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#license-002> ;
+    dcterms:issued "2004-06-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A legal document giving official permission to do something with the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "License"@en ;
+    rdfs:range dcterms:LicenseDocument ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/rights>, dcterms:rights .
+
+dcterms:mediator
+    dcterms:description "In an educational context, a mediator might be a parent, teacher, teaching assistant, or care-giver."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#mediator-003> ;
+    dcterms:issued "2001-05-21"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "An entity that mediates access to the resource and for whom the resource is intended or useful."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Mediator"@en ;
+    rdfs:range dcterms:AgentClass ;
+    rdfs:subPropertyOf dcterms:audience .
+
+dcterms:medium
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#medium-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "The material or physical carrier of the resource."@en ;
+    rdfs:domain dcterms:PhysicalResource ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Medium"@en ;
+    rdfs:range dcterms:PhysicalMedium ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/format>, dcterms:format .
+
+dcterms:modified
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#modified-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "Date on which the resource was changed."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Date Modified"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/date>, dcterms:date .
+
+dcterms:provenance
+    dcterms:description "The statement may include a description of any changes successive custodians made to the resource."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#provenance-002> ;
+    dcterms:issued "2004-09-20"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A statement of any changes in ownership and custody of the resource since its creation that are significant for its authenticity, integrity, and interpretation."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Provenance"@en ;
+    rdfs:range dcterms:ProvenanceStatement .
+
+dcterms:publisher
+    dcterms:description "Examples of a Publisher include a person, an organization, or a service."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#publisherT-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2010-10-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "An entity responsible for making the resource available."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Publisher"@en ;
+    rdfs:range dcterms:Agent ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/publisher> .
+
+dcterms:references
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#references-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource that is referenced, cited, or otherwise pointed to by the described resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "References"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:relation
+    dcterms:description "Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system. "@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#relationT-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Relation"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation> ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:replaces
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#replaces-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource that is supplanted, displaced, or superseded by the described resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Replaces"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:requires
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#requires-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource that is required by the described resource to support its function, delivery, or coherence."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Requires"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/relation>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:rights
+    dcterms:description "Typically, rights information includes a statement about various property rights associated with the resource, including intellectual property rights."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#rightsT-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "Information about rights held in and over the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Rights"@en ;
+    rdfs:range dcterms:RightsStatement ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/rights> .
+
+dcterms:rightsHolder
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#rightsHolder-002> ;
+    dcterms:issued "2004-06-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A person or organization owning or managing rights over the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Rights Holder"@en ;
+    rdfs:range dcterms:Agent .
+
+dcterms:source
+    dcterms:description "The described resource may be derived from the related resource in whole or in part. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#sourceT-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A related resource from which the described resource is derived."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Source"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/source>, dcterms:relation ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:spatial
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#spatial-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "Spatial characteristics of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Spatial Coverage"@en ;
+    rdfs:range dcterms:Location ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/coverage>, dcterms:coverage .
+
+dcterms:subject
+    dcterms:description "Typically, the subject will be represented using keywords, key phrases, or classification codes. Recommended best practice is to use a controlled vocabulary."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#subjectT-002> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2012-06-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "The topic of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Subject"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/subject> ;
+    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+dcterms:tableOfContents
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#tableOfContents-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A list of subunits of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Table Of Contents"@en ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/description>, dcterms:description .
+
+dcterms:temporal
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#temporal-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "Temporal characteristics of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Temporal Coverage"@en ;
+    rdfs:range dcterms:PeriodOfTime ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/coverage>, dcterms:coverage .
+
+dcterms:title
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#titleT-002> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2010-10-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "A name given to the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Title"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/title> .
+
+dcterms:type
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the DCMI Type Vocabulary [DCMITYPE]. To describe the file format, physical medium, or dimensions of the resource, use the Format element."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#typeT-001> ;
+    dcterms:issued "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "The nature or genre of the resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Type"@en ;
+    rdfs:range rdfs:Class ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/type> .
+
+dcterms:valid
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#valid-003> ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:modified "2008-01-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdf:Property ;
+    rdfs:comment "Date (often a range) of validity of a resource."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
+    rdfs:label "Date Valid"@en ;
+    rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf <http://purl.org/dc/elements/1.1/date>, dcterms:date .
+

--- a/resources/foaf.ttl
+++ b/resources/foaf.ttl
@@ -1,0 +1,697 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix wot: <http://xmlns.com/wot/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ns0: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+foaf:
+  a owl:Ontology ;
+  dc11:description "The Friend of a Friend (FOAF) RDF vocabulary, described using W3C RDF Schema and the Web Ontology Language." .
+
+wot:assurance a owl:AnnotationProperty .
+wot:src_assurance a owl:AnnotationProperty .
+<http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> a owl:AnnotationProperty .
+dc11:description a owl:AnnotationProperty .
+dc11:date a owl:AnnotationProperty .
+rdfs:Class a owl:Class .
+foaf:LabelProperty
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "unstable" ;
+  rdfs:label "Label Property" ;
+  rdfs:comment "A foaf:LabelProperty is any RDF property with texual values that serve as labels." ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:Person
+  a rdfs:Class, owl:Class ;
+  rdfs:label "Person" ;
+  rdfs:comment "A person." ;
+  ns0:term_status "stable" ;
+  owl:equivalentClass schema:Person, <http://www.w3.org/2000/10/swap/pim/contact#Person> ;
+  rdfs:subClassOf foaf:Agent, geo:SpatialThing ;
+  rdfs:isDefinedBy foaf: ;
+  owl:disjointWith foaf:Organization, foaf:Project .
+
+foaf:Agent
+  a owl:Class, rdfs:Class ;
+  ns0:term_status "stable" ;
+  rdfs:label "Agent" ;
+  rdfs:comment "An agent (eg. person, group, software or physical artifact)." ;
+  owl:equivalentClass dc:Agent .
+
+geo:SpatialThing
+  a owl:Class ;
+  rdfs:label "Spatial Thing" .
+
+foaf:Document
+  a rdfs:Class, owl:Class ;
+  rdfs:label "Document" ;
+  rdfs:comment "A document." ;
+  ns0:term_status "stable" ;
+  owl:equivalentClass schema:CreativeWork ;
+  rdfs:isDefinedBy foaf: ;
+  owl:disjointWith foaf:Organization, foaf:Project .
+
+foaf:Organization
+  a rdfs:Class, owl:Class ;
+  rdfs:label "Organization" ;
+  rdfs:comment "An organization." ;
+  ns0:term_status "stable" ;
+  rdfs:subClassOf foaf:Agent ;
+  rdfs:isDefinedBy foaf: ;
+  owl:disjointWith foaf:Person, foaf:Document .
+
+foaf:Group
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "stable" ;
+  rdfs:label "Group" ;
+  rdfs:comment "A class of Agents." ;
+  rdfs:subClassOf foaf:Agent .
+
+foaf:Project
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "testing" ;
+  rdfs:label "Project" ;
+  rdfs:comment "A project (a collective endeavour of some kind)." ;
+  rdfs:isDefinedBy foaf: ;
+  owl:disjointWith foaf:Person, foaf:Document .
+
+foaf:Image
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "stable" ;
+  rdfs:label "Image" ;
+  rdfs:comment "An image." ;
+  owl:equivalentClass schema:ImageObject ;
+  rdfs:subClassOf foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:PersonalProfileDocument
+  a rdfs:Class, owl:Class ;
+  rdfs:label "PersonalProfileDocument" ;
+  rdfs:comment "A personal profile RDF document." ;
+  ns0:term_status "testing" ;
+  rdfs:subClassOf foaf:Document .
+
+foaf:OnlineAccount
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "testing" ;
+  rdfs:label "Online Account" ;
+  rdfs:comment "An online account." ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subClassOf owl:Thing .
+
+owl:Thing rdfs:label "Thing" .
+foaf:OnlineGamingAccount
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "unstable" ;
+  rdfs:label "Online Gaming Account" ;
+  rdfs:comment "An online gaming account." ;
+  rdfs:subClassOf foaf:OnlineAccount ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:OnlineEcommerceAccount
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "unstable" ;
+  rdfs:label "Online E-commerce Account" ;
+  rdfs:comment "An online e-commerce account." ;
+  rdfs:subClassOf foaf:OnlineAccount ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:OnlineChatAccount
+  a rdfs:Class, owl:Class ;
+  ns0:term_status "unstable" ;
+  rdfs:label "Online Chat Account" ;
+  rdfs:comment "An online chat account." ;
+  rdfs:subClassOf foaf:OnlineAccount ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:mbox
+  a rdf:Property, owl:InverseFunctionalProperty, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "personal mailbox" ;
+  rdfs:comment "A  personal mailbox, ie. an Internet mailbox associated with exactly one owner, the first owner of this mailbox. This is a 'static inverse functional property', in that  there is (across time and change) at most one individual that ever has any particular value for foaf:mbox." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:mbox_sha1sum
+  a rdf:Property, owl:InverseFunctionalProperty, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "sha1sum of a personal mailbox URI name" ;
+  rdfs:comment "The sha1sum of the URI of an Internet mailbox associated with exactly one owner, the  first owner of the mailbox." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:gender
+  a rdf:Property, owl:FunctionalProperty, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "gender" ;
+  rdfs:comment "The gender of this Agent (typically but not necessarily 'male' or 'female')." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:geekcode
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "geekcode" ;
+  rdfs:comment "A textual geekcode for this person, see http://www.geekcode.com/geek.html" ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:dnaChecksum
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "DNA checksum" ;
+  rdfs:comment "A checksum for the DNA of some thing. Joke." ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:range rdfs:Literal .
+
+foaf:sha1
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "unstable" ;
+  rdfs:label "sha1sum (hex)" ;
+  rdfs:comment "A sha1sum hash, in hex." ;
+  rdfs:domain foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:based_near
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "based near" ;
+  rdfs:comment "A location that something is based near, for some broadly human notion of near." ;
+  rdfs:domain geo:SpatialThing ;
+  rdfs:range geo:SpatialThing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:title
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "title" ;
+  rdfs:comment "Title (Mr, Mrs, Ms, Dr. etc)" ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:nick
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "nickname" ;
+  rdfs:comment "A short informal nickname characterising an agent (includes login identifiers, IRC and other chat nicknames)." ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:jabberID
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "jabber ID" ;
+  rdfs:comment "A jabber ID for something." ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal .
+
+foaf:aimChatID
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "AIM chat ID" ;
+  rdfs:comment "An AIM chat ID" ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subPropertyOf foaf:nick ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal .
+
+foaf:skypeID
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "Skype ID" ;
+  rdfs:comment "A Skype ID" ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subPropertyOf foaf:nick ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal .
+
+foaf:icqChatID
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "ICQ chat ID" ;
+  rdfs:comment "An ICQ chat ID" ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subPropertyOf foaf:nick ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal .
+
+foaf:yahooChatID
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "Yahoo chat ID" ;
+  rdfs:comment "A Yahoo chat ID" ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subPropertyOf foaf:nick ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal .
+
+foaf:msnChatID
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "MSN chat ID" ;
+  rdfs:comment "An MSN chat ID" ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subPropertyOf foaf:nick ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal .
+
+foaf:name
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "name" ;
+  rdfs:comment "A name for some thing." ;
+  rdfs:domain owl:Thing ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:subPropertyOf rdfs:label .
+
+foaf:firstName
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "firstName" ;
+  rdfs:comment "The first name of a person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:lastName
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "lastName" ;
+  rdfs:comment "The last name of a person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:givenName
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "Given name" ;
+  rdfs:comment "The given name of some person." ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:givenname
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "Given name" ;
+  rdfs:comment "The given name of some person." ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:surname
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "Surname" ;
+  rdfs:comment "The surname of some person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:family_name
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "family_name" ;
+  rdfs:comment "The family name of some person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:familyName
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "familyName" ;
+  rdfs:comment "The family name of some person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:phone
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "phone" ;
+  rdfs:comment "A phone,  specified using fully qualified tel: URI scheme (refs: http://www.w3.org/Addressing/schemes.html#tel)." ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:homepage
+  a rdf:Property, owl:ObjectProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "homepage" ;
+  rdfs:comment "A homepage for some thing." ;
+  rdfs:subPropertyOf foaf:page, foaf:isPrimaryTopicOf ;
+  rdfs:domain owl:Thing ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:weblog
+  a rdf:Property, owl:ObjectProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "weblog" ;
+  rdfs:comment "A weblog of some thing (whether person, group, company etc.)." ;
+  rdfs:subPropertyOf foaf:page ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:openid
+  a rdf:Property, owl:ObjectProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "openid" ;
+  rdfs:comment "An OpenID for an Agent." ;
+  rdfs:subPropertyOf foaf:isPrimaryTopicOf ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:tipjar
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "tipjar" ;
+  rdfs:comment "A tipjar document for this agent, describing means for payment and reward." ;
+  rdfs:subPropertyOf foaf:page ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:plan
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "plan" ;
+  rdfs:comment "A .plan comment, in the tradition of finger and '.plan' files." ;
+  rdfs:isDefinedBy foaf: ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal .
+
+foaf:made
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "made" ;
+  rdfs:comment "Something that was made by this agent." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: ;
+  owl:inverseOf foaf:maker .
+
+foaf:maker
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "maker" ;
+  rdfs:comment "An agent that  made this thing." ;
+  owl:equivalentProperty dc:creator ;
+  rdfs:domain owl:Thing ;
+  rdfs:range foaf:Agent ;
+  rdfs:isDefinedBy foaf: ;
+  owl:inverseOf foaf:made .
+
+foaf:img
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "image" ;
+  rdfs:comment "An image that can be used to represent some thing (ie. those depictions which are particularly representative of something, eg. one's photo on a homepage)." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range foaf:Image ;
+  rdfs:subPropertyOf foaf:depiction ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:depiction
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "depiction" ;
+  rdfs:comment "A depiction of some thing." ;
+  rdfs:domain owl:Thing ;
+  rdfs:range foaf:Image ;
+  rdfs:isDefinedBy foaf: ;
+  owl:inverseOf foaf:depicts .
+
+foaf:depicts
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "depicts" ;
+  rdfs:comment "A thing depicted in this representation." ;
+  rdfs:range owl:Thing ;
+  rdfs:domain foaf:Image ;
+  rdfs:isDefinedBy foaf: ;
+  owl:inverseOf foaf:depiction .
+
+foaf:thumbnail
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "thumbnail" ;
+  rdfs:comment "A derived thumbnail image." ;
+  rdfs:domain foaf:Image ;
+  rdfs:range foaf:Image ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:myersBriggs
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "myersBriggs" ;
+  rdfs:comment "A Myers Briggs (MBTI) personality classification." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:workplaceHomepage
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "workplace homepage" ;
+  rdfs:comment "A workplace homepage of some person; the homepage of an organization they work for." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:workInfoHomepage
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "work info homepage" ;
+  rdfs:comment "A work info homepage of some person; a page about their work for some organization." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:schoolHomepage
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "schoolHomepage" ;
+  rdfs:comment "A homepage of a school attended by the person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:knows
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "knows" ;
+  rdfs:comment "A person known by this person (indicating some level of reciprocated interaction between the parties)." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range foaf:Person ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:interest
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "interest" ;
+  rdfs:comment "A page about a topic of interest to this person." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:topic_interest
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "topic_interest" ;
+  rdfs:comment "A thing of interest to this person." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:publications
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "publications" ;
+  rdfs:comment "A link to the publications of this person." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:currentProject
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "current project" ;
+  rdfs:comment "A current project this person works on." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:pastProject
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "past project" ;
+  rdfs:comment "A project this person has previously worked on." ;
+  rdfs:domain foaf:Person ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:fundedBy
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "funded by" ;
+  rdfs:comment "An organization funding a project or person." ;
+  rdfs:domain owl:Thing ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:logo
+  a rdf:Property, owl:ObjectProperty, owl:InverseFunctionalProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "logo" ;
+  rdfs:comment "A logo representing some thing." ;
+  rdfs:domain owl:Thing ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:topic
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "topic" ;
+  rdfs:comment "A topic of some page or document." ;
+  rdfs:domain foaf:Document ;
+  rdfs:range owl:Thing ;
+  owl:inverseOf foaf:page ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:primaryTopic
+  a rdf:Property, owl:FunctionalProperty, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "primary topic" ;
+  rdfs:comment "The primary topic of some page or document." ;
+  rdfs:domain foaf:Document ;
+  rdfs:range owl:Thing ;
+  owl:inverseOf foaf:isPrimaryTopicOf ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:focus
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "focus" ;
+  rdfs:comment "The underlying or 'focal' entity associated with some SKOS-described concept." ;
+  rdfs:domain skos:Concept ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+skos:Concept rdfs:label "Concept" .
+foaf:isPrimaryTopicOf
+  a rdf:Property, owl:InverseFunctionalProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "is primary topic of" ;
+  rdfs:comment "A document that this thing is the primary topic of." ;
+  rdfs:subPropertyOf foaf:page ;
+  owl:inverseOf foaf:primaryTopic ;
+  rdfs:domain owl:Thing ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:page
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "page" ;
+  rdfs:comment "A page or document about this thing." ;
+  rdfs:domain owl:Thing ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: ;
+  owl:inverseOf foaf:topic .
+
+foaf:theme
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "theme" ;
+  rdfs:comment "A theme." ;
+  rdfs:domain owl:Thing ;
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:account
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "account" ;
+  rdfs:comment "Indicates an account held by this agent." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range foaf:OnlineAccount ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:holdsAccount
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "archaic" ;
+  rdfs:label "account" ;
+  rdfs:comment "Indicates an account held by this agent." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range foaf:OnlineAccount ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:accountServiceHomepage
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "account service homepage" ;
+  rdfs:comment "Indicates a homepage of the service provide for this online account." ;
+  rdfs:domain foaf:OnlineAccount ;
+  rdfs:range foaf:Document ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:accountName
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "testing" ;
+  rdfs:label "account name" ;
+  rdfs:comment "Indicates the name (identifier) associated with this online account." ;
+  rdfs:domain foaf:OnlineAccount ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:member
+  a rdf:Property, owl:ObjectProperty ;
+  ns0:term_status "stable" ;
+  rdfs:label "member" ;
+  rdfs:comment "Indicates a member of a Group" ;
+  rdfs:domain foaf:Group ;
+  rdfs:range foaf:Agent ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:membershipClass
+  a rdf:Property, owl:AnnotationProperty ;
+  ns0:term_status "unstable" ;
+  rdfs:label "membershipClass" ;
+  rdfs:comment "Indicates the class of individuals that are a member of a Group" ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:birthday
+  a rdf:Property, owl:FunctionalProperty, owl:DatatypeProperty ;
+  ns0:term_status "unstable" ;
+  rdfs:label "birthday" ;
+  rdfs:comment "The birthday of this Agent, represented in mm-dd string form, eg. '12-31'." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:age
+  a rdf:Property, owl:FunctionalProperty, owl:DatatypeProperty ;
+  ns0:term_status "unstable" ;
+  rdfs:label "age" ;
+  rdfs:comment "The age in years of some agent." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .
+
+foaf:status
+  a rdf:Property, owl:DatatypeProperty ;
+  ns0:term_status "unstable" ;
+  rdfs:label "status" ;
+  rdfs:comment "A string expressing what the user is happy for the general public (normally) to know about their current activity." ;
+  rdfs:domain foaf:Agent ;
+  rdfs:range rdfs:Literal ;
+  rdfs:isDefinedBy foaf: .

--- a/resources/owl.ttl
+++ b/resources/owl.ttl
@@ -1,0 +1,620 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://www.w3.org/2002/07/owl>
+    rdfs:label "The OWL 2 Schema vocabulary (OWL 2)" ;
+    a owl:Ontology ;
+    rdfs:comment """
+  This ontology partially describes the built-in classes and
+  properties that together form the basis of the RDF/XML syntax of OWL 2.
+  The content of this ontology is based on Tables 6.1 and 6.2
+  in Section 6.4 of the OWL 2 RDF-Based Semantics specification,
+  available at http://www.w3.org/TR/owl2-rdf-based-semantics/.
+  Please note that those tables do not include the different annotations
+  (labels, comments and rdfs:isDefinedBy links) used in this file.
+  Also note that the descriptions provided in this ontology do not
+  provide a complete and correct formal description of either the syntax
+  or the semantics of the introduced terms (please see the OWL 2
+  recommendations for the complete and normative specifications).
+  Furthermore, the information provided by this ontology may be
+  misleading if not used with care. This ontology SHOULD NOT be imported
+  into OWL ontologies. Importing this file into an OWL 2 DL ontology
+  will cause it to become an OWL 2 Full ontology and may have other,
+  unexpected, consequences.
+   """ ;
+    rdfs:isDefinedBy <http://www.w3.org/TR/owl2-mapping-to-rdf/>, <http://www.w3.org/TR/owl2-rdf-based-semantics/>, <http://www.w3.org/TR/owl2-syntax/> ;
+    rdfs:seeAlso <http://www.w3.org/TR/owl2-rdf-based-semantics/#table-axiomatic-classes>, <http://www.w3.org/TR/owl2-rdf-based-semantics/#table-axiomatic-properties> ;
+    <http://purl.org/vocab/vann/preferredNamespaceUri> "http://www.w3.org/2002/07/owl#";
+    owl:imports <http://www.w3.org/2000/01/rdf-schema> .
+
+owl:AllDifferent
+    a rdfs:Class ;
+    rdfs:comment "The class of collections of pairwise different individuals." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "AllDifferent" ;
+    rdfs:subClassOf rdfs:Resource .
+
+owl:AllDisjointClasses
+    a rdfs:Class ;
+    rdfs:comment "The class of collections of pairwise disjoint classes." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "AllDisjointClasses" ;
+    rdfs:subClassOf rdfs:Resource .
+
+owl:AllDisjointProperties
+    a rdfs:Class ;
+    rdfs:comment "The class of collections of pairwise disjoint properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "AllDisjointProperties" ;
+    rdfs:subClassOf rdfs:Resource .
+
+owl:Annotation
+    a rdfs:Class ;
+    rdfs:comment "The class of annotated annotations for which the RDF serialization consists of an annotated subject, predicate and object." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "Annotation" ;
+    rdfs:subClassOf rdfs:Resource .
+
+owl:AnnotationProperty
+    a rdfs:Class ;
+    rdfs:comment "The class of annotation properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "AnnotationProperty" ;
+    rdfs:subClassOf rdf:Property .
+
+owl:AsymmetricProperty
+    a rdfs:Class ;
+    rdfs:comment "The class of asymmetric properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "AsymmetricProperty" ;
+    rdfs:subClassOf owl:ObjectProperty .
+
+owl:Axiom
+    a rdfs:Class ;
+    rdfs:comment "The class of annotated axioms for which the RDF serialization consists of an annotated subject, predicate and object." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "Axiom" ;
+    rdfs:subClassOf rdfs:Resource .
+
+owl:Class
+    a rdfs:Class ;
+    rdfs:comment "The class of OWL classes." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "Class" ;
+    rdfs:subClassOf rdfs:Class .
+
+owl:DataRange
+    a rdfs:Class ;
+    rdfs:comment "The class of OWL data ranges, which are special kinds of datatypes. Note: The use of the IRI owl:DataRange has been deprecated as of OWL 2. The IRI rdfs:Datatype SHOULD be used instead." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "DataRange" ;
+    rdfs:subClassOf rdfs:Datatype .
+
+owl:DatatypeProperty
+    a rdfs:Class ;
+    rdfs:comment "The class of data properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "DatatypeProperty" ;
+    rdfs:subClassOf rdf:Property .
+
+owl:DeprecatedClass
+    a rdfs:Class ;
+    rdfs:comment "The class of deprecated classes." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "DeprecatedClass" ;
+    rdfs:subClassOf rdfs:Class .
+
+owl:DeprecatedProperty
+    a rdfs:Class ;
+    rdfs:comment "The class of deprecated properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "DeprecatedProperty" ;
+    rdfs:subClassOf rdf:Property .
+
+owl:FunctionalProperty
+    a rdfs:Class ;
+    rdfs:comment "The class of functional properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "FunctionalProperty" ;
+    rdfs:subClassOf rdf:Property .
+
+owl:InverseFunctionalProperty
+    a rdfs:Class ;
+    rdfs:comment "The class of inverse-functional properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "InverseFunctionalProperty" ;
+    rdfs:subClassOf owl:ObjectProperty .
+
+owl:IrreflexiveProperty
+    a rdfs:Class ;
+    rdfs:comment "The class of irreflexive properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "IrreflexiveProperty" ;
+    rdfs:subClassOf owl:ObjectProperty .
+
+owl:NamedIndividual
+    a rdfs:Class ;
+    rdfs:comment "The class of named individuals." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "NamedIndividual" ;
+    rdfs:subClassOf owl:Thing .
+
+owl:NegativePropertyAssertion
+    a rdfs:Class ;
+    rdfs:comment "The class of negative property assertions." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "NegativePropertyAssertion" ;
+    rdfs:subClassOf rdfs:Resource .
+
+owl:Nothing
+    a owl:Class ;
+    rdfs:comment "This is the empty class." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "Nothing" ;
+    rdfs:subClassOf owl:Thing .
+
+owl:ObjectProperty
+    a rdfs:Class ;
+    rdfs:comment "The class of object properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "ObjectProperty" ;
+    rdfs:subClassOf rdf:Property .
+
+owl:Ontology
+    a rdfs:Class ;
+    rdfs:comment "The class of ontologies." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "Ontology" ;
+    rdfs:subClassOf rdfs:Resource .
+
+owl:OntologyProperty
+    a rdfs:Class ;
+    rdfs:comment "The class of ontology properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "OntologyProperty" ;
+    rdfs:subClassOf rdf:Property .
+
+owl:ReflexiveProperty
+    a rdfs:Class ;
+    rdfs:comment "The class of reflexive properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "ReflexiveProperty" ;
+    rdfs:subClassOf owl:ObjectProperty .
+
+owl:Restriction
+    a rdfs:Class ;
+    rdfs:comment "The class of property restrictions." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "Restriction" ;
+    rdfs:subClassOf owl:Class .
+
+owl:SymmetricProperty
+    a rdfs:Class ;
+    rdfs:comment "The class of symmetric properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "SymmetricProperty" ;
+    rdfs:subClassOf owl:ObjectProperty .
+
+owl:Thing
+    a owl:Class ;
+    rdfs:comment "The class of OWL individuals." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "Thing" .
+
+owl:TransitiveProperty
+    a rdfs:Class ;
+    rdfs:comment "The class of transitive properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "TransitiveProperty" ;
+    rdfs:subClassOf owl:ObjectProperty .
+
+owl:allValuesFrom
+    a rdf:Property ;
+    rdfs:comment "The property that determines the class that a universal property restriction refers to." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "allValuesFrom" ;
+    rdfs:range rdfs:Class .
+
+owl:annotatedProperty
+    a rdf:Property ;
+    rdfs:comment "The property that determines the predicate of an annotated axiom or annotated annotation." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "annotatedProperty" ;
+    rdfs:range rdfs:Resource .
+
+owl:annotatedSource
+    a rdf:Property ;
+    rdfs:comment "The property that determines the subject of an annotated axiom or annotated annotation." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "annotatedSource" ;
+    rdfs:range rdfs:Resource .
+
+owl:annotatedTarget
+    a rdf:Property ;
+    rdfs:comment "The property that determines the object of an annotated axiom or annotated annotation." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "annotatedTarget" ;
+    rdfs:range rdfs:Resource .
+
+owl:assertionProperty
+    a rdf:Property ;
+    rdfs:comment "The property that determines the predicate of a negative property assertion." ;
+    rdfs:domain owl:NegativePropertyAssertion ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "assertionProperty" ;
+    rdfs:range rdf:Property .
+
+owl:backwardCompatibleWith
+    a owl:AnnotationProperty, owl:OntologyProperty ;
+    rdfs:comment "The annotation property that indicates that a given ontology is backward compatible with another ontology." ;
+    rdfs:domain owl:Ontology ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "backwardCompatibleWith" ;
+    rdfs:range owl:Ontology .
+
+owl:bottomDataProperty
+    a owl:DatatypeProperty ;
+    rdfs:comment "The data property that does not relate any individual to any data value." ;
+    rdfs:domain owl:Thing ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "bottomDataProperty" ;
+    rdfs:range rdfs:Literal .
+
+owl:bottomObjectProperty
+    a owl:ObjectProperty ;
+    rdfs:comment "The object property that does not relate any two individuals." ;
+    rdfs:domain owl:Thing ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "bottomObjectProperty" ;
+    rdfs:range owl:Thing .
+
+owl:cardinality
+    a rdf:Property ;
+    rdfs:comment "The property that determines the cardinality of an exact cardinality restriction." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "cardinality" ;
+    rdfs:range xsd:nonNegativeInteger .
+
+owl:complementOf
+    a rdf:Property ;
+    rdfs:comment "The property that determines that a given class is the complement of another class." ;
+    rdfs:domain owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "complementOf" ;
+    rdfs:range owl:Class .
+
+owl:datatypeComplementOf
+    a rdf:Property ;
+    rdfs:comment "The property that determines that a given data range is the complement of another data range with respect to the data domain." ;
+    rdfs:domain rdfs:Datatype ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "datatypeComplementOf" ;
+    rdfs:range rdfs:Datatype .
+
+owl:deprecated
+    a owl:AnnotationProperty ;
+    rdfs:comment "The annotation property that indicates that a given entity has been deprecated." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "deprecated" ;
+    rdfs:range rdfs:Resource .
+
+owl:differentFrom
+    a rdf:Property ;
+    rdfs:comment "The property that determines that two given individuals are different." ;
+    rdfs:domain owl:Thing ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "differentFrom" ;
+    rdfs:range owl:Thing .
+
+owl:disjointUnionOf
+    a rdf:Property ;
+    rdfs:comment "The property that determines that a given class is equivalent to the disjoint union of a collection of other classes." ;
+    rdfs:domain owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "disjointUnionOf" ;
+    rdfs:range rdf:List .
+
+owl:disjointWith
+    a rdf:Property ;
+    rdfs:comment "The property that determines that two given classes are disjoint." ;
+    rdfs:domain owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "disjointWith" ;
+    rdfs:range owl:Class .
+
+owl:distinctMembers
+    a rdf:Property ;
+    rdfs:comment "The property that determines the collection of pairwise different individuals in a owl:AllDifferent axiom." ;
+    rdfs:domain owl:AllDifferent ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "distinctMembers" ;
+    rdfs:range rdf:List .
+
+owl:equivalentClass
+    a rdf:Property ;
+    rdfs:comment "The property that determines that two given classes are equivalent, and that is used to specify datatype definitions." ;
+    rdfs:domain rdfs:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "equivalentClass" ;
+    rdfs:range rdfs:Class .
+
+owl:equivalentProperty
+    a rdf:Property ;
+    rdfs:comment "The property that determines that two given properties are equivalent." ;
+    rdfs:domain rdf:Property ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "equivalentProperty" ;
+    rdfs:range rdf:Property .
+
+owl:hasKey
+    a rdf:Property ;
+    rdfs:comment "The property that determines the collection of properties that jointly build a key." ;
+    rdfs:domain owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "hasKey" ;
+    rdfs:range rdf:List .
+
+owl:hasSelf
+    a rdf:Property ;
+    rdfs:comment "The property that determines the property that a self restriction refers to." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "hasSelf" ;
+    rdfs:range rdfs:Resource .
+
+owl:hasValue
+    a rdf:Property ;
+    rdfs:comment "The property that determines the individual that a has-value restriction refers to." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "hasValue" ;
+    rdfs:range rdfs:Resource .
+
+owl:imports
+    a owl:OntologyProperty ;
+    rdfs:comment "The property that is used for importing other ontologies into a given ontology." ;
+    rdfs:domain owl:Ontology ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "imports" ;
+    rdfs:range owl:Ontology .
+
+owl:incompatibleWith
+    a owl:AnnotationProperty, owl:OntologyProperty ;
+    rdfs:comment "The annotation property that indicates that a given ontology is incompatible with another ontology." ;
+    rdfs:domain owl:Ontology ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "incompatibleWith" ;
+    rdfs:range owl:Ontology .
+
+owl:intersectionOf
+    a rdf:Property ;
+    rdfs:comment "The property that determines the collection of classes or data ranges that build an intersection." ;
+    rdfs:domain rdfs:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "intersectionOf" ;
+    rdfs:range rdf:List .
+
+owl:inverseOf
+    a rdf:Property ;
+    rdfs:comment "The property that determines that two given properties are inverse." ;
+    rdfs:domain owl:ObjectProperty ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "inverseOf" ;
+    rdfs:range owl:ObjectProperty .
+
+owl:maxCardinality
+    a rdf:Property ;
+    rdfs:comment "The property that determines the cardinality of a maximum cardinality restriction." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "maxCardinality" ;
+    rdfs:range xsd:nonNegativeInteger .
+
+owl:maxQualifiedCardinality
+    a rdf:Property ;
+    rdfs:comment "The property that determines the cardinality of a maximum qualified cardinality restriction." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "maxQualifiedCardinality" ;
+    rdfs:range xsd:nonNegativeInteger .
+
+owl:members
+    a rdf:Property ;
+    rdfs:comment "The property that determines the collection of members in either a owl:AllDifferent, owl:AllDisjointClasses or owl:AllDisjointProperties axiom." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "members" ;
+    rdfs:range rdf:List .
+
+owl:minCardinality
+    a rdf:Property ;
+    rdfs:comment "The property that determines the cardinality of a minimum cardinality restriction." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "minCardinality" ;
+    rdfs:range xsd:nonNegativeInteger .
+
+owl:minQualifiedCardinality
+    a rdf:Property ;
+    rdfs:comment "The property that determines the cardinality of a minimum qualified cardinality restriction." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "minQualifiedCardinality" ;
+    rdfs:range xsd:nonNegativeInteger .
+
+owl:onClass
+    a rdf:Property ;
+    rdfs:comment "The property that determines the class that a qualified object cardinality restriction refers to." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "onClass" ;
+    rdfs:range owl:Class .
+
+owl:onDataRange
+    a rdf:Property ;
+    rdfs:comment "The property that determines the data range that a qualified data cardinality restriction refers to." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "onDataRange" ;
+    rdfs:range rdfs:Datatype .
+
+owl:onDatatype
+    a rdf:Property ;
+    rdfs:comment "The property that determines the datatype that a datatype restriction refers to." ;
+    rdfs:domain rdfs:Datatype ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "onDatatype" ;
+    rdfs:range rdfs:Datatype .
+
+owl:onProperties
+    a rdf:Property ;
+    rdfs:comment "The property that determines the n-tuple of properties that a property restriction on an n-ary data range refers to." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "onProperties" ;
+    rdfs:range rdf:List .
+
+owl:onProperty
+    a rdf:Property ;
+    rdfs:comment "The property that determines the property that a property restriction refers to." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "onProperty" ;
+    rdfs:range rdf:Property .
+
+owl:oneOf
+    a rdf:Property ;
+    rdfs:comment "The property that determines the collection of individuals or data values that build an enumeration." ;
+    rdfs:domain rdfs:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "oneOf" ;
+    rdfs:range rdf:List .
+
+owl:priorVersion
+    a owl:AnnotationProperty, owl:OntologyProperty ;
+    rdfs:comment "The annotation property that indicates the predecessor ontology of a given ontology." ;
+    rdfs:domain owl:Ontology ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "priorVersion" ;
+    rdfs:range owl:Ontology .
+
+owl:propertyChainAxiom
+    a rdf:Property ;
+    rdfs:comment "The property that determines the n-tuple of properties that build a sub property chain of a given property." ;
+    rdfs:domain owl:ObjectProperty ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "propertyChainAxiom" ;
+    rdfs:range rdf:List .
+
+owl:propertyDisjointWith
+    a rdf:Property ;
+    rdfs:comment "The property that determines that two given properties are disjoint." ;
+    rdfs:domain rdf:Property ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "propertyDisjointWith" ;
+    rdfs:range rdf:Property .
+
+owl:qualifiedCardinality
+    a rdf:Property ;
+    rdfs:comment "The property that determines the cardinality of an exact qualified cardinality restriction." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "qualifiedCardinality" ;
+    rdfs:range xsd:nonNegativeInteger .
+
+owl:sameAs
+    a rdf:Property ;
+    rdfs:comment "The property that determines that two given individuals are equal." ;
+    rdfs:domain owl:Thing ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "sameAs" ;
+    rdfs:range owl:Thing .
+
+owl:someValuesFrom
+    a rdf:Property ;
+    rdfs:comment "The property that determines the class that an existential property restriction refers to." ;
+    rdfs:domain owl:Restriction ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "someValuesFrom" ;
+    rdfs:range rdfs:Class .
+
+owl:sourceIndividual
+    a rdf:Property ;
+    rdfs:comment "The property that determines the subject of a negative property assertion." ;
+    rdfs:domain owl:NegativePropertyAssertion ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "sourceIndividual" ;
+    rdfs:range owl:Thing .
+
+owl:targetIndividual
+    a rdf:Property ;
+    rdfs:comment "The property that determines the object of a negative object property assertion." ;
+    rdfs:domain owl:NegativePropertyAssertion ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "targetIndividual" ;
+    rdfs:range owl:Thing .
+
+owl:targetValue
+    a rdf:Property ;
+    rdfs:comment "The property that determines the value of a negative data property assertion." ;
+    rdfs:domain owl:NegativePropertyAssertion ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "targetValue" ;
+    rdfs:range rdfs:Literal .
+
+owl:topDataProperty
+    a owl:DatatypeProperty ;
+    rdfs:comment "The data property that relates every individual to every data value." ;
+    rdfs:domain owl:Thing ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "topDataProperty" ;
+    rdfs:range rdfs:Literal .
+
+owl:topObjectProperty
+    a owl:ObjectProperty ;
+    rdfs:comment "The object property that relates every two individuals." ;
+    rdfs:domain owl:Thing ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "topObjectProperty" ;
+    rdfs:range owl:Thing .
+
+owl:unionOf
+    a rdf:Property ;
+    rdfs:comment "The property that determines the collection of classes or data ranges that build a union." ;
+    rdfs:domain rdfs:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "unionOf" ;
+    rdfs:range rdf:List .
+
+owl:versionIRI
+    a owl:OntologyProperty ;
+    rdfs:comment "The property that identifies the version IRI of an ontology." ;
+    rdfs:domain owl:Ontology ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "versionIRI" ;
+    rdfs:range owl:Ontology .
+
+owl:versionInfo
+    a owl:AnnotationProperty ;
+    rdfs:comment "The annotation property that provides version information for an ontology or another OWL construct." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "versionInfo" ;
+    rdfs:range rdfs:Resource .
+
+owl:withRestrictions
+    a rdf:Property ;
+    rdfs:comment "The property that determines the collection of facet-value pairs that define a datatype restriction." ;
+    rdfs:domain rdfs:Datatype ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+    rdfs:label "withRestrictions" ;
+    rdfs:range rdf:List .
+

--- a/resources/rdf.ttl
+++ b/resources/rdf.ttl
@@ -1,0 +1,144 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    rdfs:comment "This is the RDF Schema for the RDF vocabulary terms in the RDF Namespace, defined in RDF 1.1 Concepts." ;
+    rdfs:label "The RDF Concepts Vocabulary (RDF)" ;
+    a owl:Ontology .
+
+rdf:Alt
+    a rdfs:Class ;
+    rdfs:comment "The class of containers of alternatives." ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "Alt" ;
+    rdfs:subClassOf rdfs:Container .
+
+rdf:Bag
+    a rdfs:Class ;
+    rdfs:comment "The class of unordered containers." ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "Bag" ;
+    rdfs:subClassOf rdfs:Container .
+
+rdf:HTML
+    a rdfs:Datatype ;
+    rdfs:comment "The datatype of RDF literals storing fragments of HTML content" ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "HTML" ;
+    rdfs:seeAlso <http://www.w3.org/TR/rdf11-concepts/#section-html> ;
+    rdfs:subClassOf rdfs:Literal .
+
+rdf:List
+    a rdfs:Class ;
+    rdfs:comment "The class of RDF Lists." ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "List" ;
+    rdfs:subClassOf rdfs:Resource .
+
+rdf:PlainLiteral
+    a rdfs:Datatype ;
+    rdfs:comment "The class of plain (i.e. untyped) literal values, as used in RIF and OWL 2" ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "PlainLiteral" ;
+    rdfs:seeAlso <http://www.w3.org/TR/rdf-plain-literal/> ;
+    rdfs:subClassOf rdfs:Literal .
+
+rdf:Property
+    a rdfs:Class ;
+    rdfs:comment "The class of RDF properties." ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "Property" ;
+    rdfs:subClassOf rdfs:Resource .
+
+rdf:Seq
+    a rdfs:Class ;
+    rdfs:comment "The class of ordered containers." ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "Seq" ;
+    rdfs:subClassOf rdfs:Container .
+
+rdf:Statement
+    a rdfs:Class ;
+    rdfs:comment "The class of RDF statements." ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "Statement" ;
+    rdfs:subClassOf rdfs:Resource .
+
+rdf:XMLLiteral
+    a rdfs:Datatype ;
+    rdfs:comment "The datatype of XML literal values." ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "XMLLiteral" ;
+    rdfs:subClassOf rdfs:Literal .
+
+rdf:first
+    a rdf:Property ;
+    rdfs:comment "The first item in the subject RDF list." ;
+    rdfs:domain rdf:List ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "first" ;
+    rdfs:range rdfs:Resource .
+
+rdf:langString
+    a rdfs:Datatype ;
+    rdfs:comment "The datatype of language-tagged string values" ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "langString" ;
+    rdfs:seeAlso <http://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal> ;
+    rdfs:subClassOf rdfs:Literal .
+
+rdf:nil
+    a rdf:List ;
+    rdfs:comment "The empty list, with no items in it. If the rest of a list is nil then the list has no more items in it." ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "nil" .
+
+rdf:object
+    a rdf:Property ;
+    rdfs:comment "The object of the subject RDF statement." ;
+    rdfs:domain rdf:Statement ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "object" ;
+    rdfs:range rdfs:Resource .
+
+rdf:predicate
+    a rdf:Property ;
+    rdfs:comment "The predicate of the subject RDF statement." ;
+    rdfs:domain rdf:Statement ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "predicate" ;
+    rdfs:range rdfs:Resource .
+
+rdf:rest
+    a rdf:Property ;
+    rdfs:comment "The rest of the subject RDF list after the first item." ;
+    rdfs:domain rdf:List ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "rest" ;
+    rdfs:range rdf:List .
+
+rdf:subject
+    a rdf:Property ;
+    rdfs:comment "The subject of the subject RDF statement." ;
+    rdfs:domain rdf:Statement ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "subject" ;
+    rdfs:range rdfs:Resource .
+
+rdf:type
+    a rdf:Property ;
+    rdfs:comment "The subject is an instance of a class." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "type" ;
+    rdfs:range rdfs:Class .
+
+rdf:value
+    a rdf:Property ;
+    rdfs:comment "Idiomatic property used for structured values." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+    rdfs:label "value" ;
+    rdfs:range rdfs:Resource .
+

--- a/resources/rdfs.ttl
+++ b/resources/rdfs.ttl
@@ -1,0 +1,125 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+<http://www.w3.org/2000/01/rdf-schema#>
+    rdfs:label "The RDF Schema vocabulary (RDFS)" ;
+    a owl:Ontology ;
+    <http://purl.org/vocab/vann/preferredNamespaceUri> "http://www.w3.org/2000/01/rdf-schema#";
+    rdfs:seeAlso <http://www.w3.org/2000/01/rdf-schema-more> .
+
+rdfs:Class
+    a rdfs:Class ;
+    rdfs:comment "The class of classes." ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "Class" ;
+    rdfs:subClassOf rdfs:Resource .
+
+rdfs:Container
+    a rdfs:Class ;
+    rdfs:comment "The class of RDF containers." ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "Container" ;
+    rdfs:subClassOf rdfs:Resource .
+
+rdfs:ContainerMembershipProperty
+    a rdfs:Class ;
+    rdfs:comment """The class of container membership properties, rdf:_1, rdf:_2, ...,
+                    all of which are sub-properties of 'member'.""" ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "ContainerMembershipProperty" ;
+    rdfs:subClassOf rdf:Property .
+
+rdfs:Datatype
+    a rdfs:Class ;
+    rdfs:comment "The class of RDF datatypes." ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "Datatype" ;
+    rdfs:subClassOf rdfs:Class .
+
+rdfs:Literal
+    a rdfs:Class ;
+    rdfs:comment "The class of literal values, eg. textual strings and integers." ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "Literal" ;
+    rdfs:subClassOf rdfs:Resource .
+
+rdfs:Resource
+    a rdfs:Class ;
+    rdfs:comment "The class resource, everything." ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "Resource" .
+
+rdfs:comment
+    a rdf:Property ;
+    rdfs:comment "A description of the subject resource." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "comment" ;
+    rdfs:range rdfs:Literal .
+
+rdfs:domain
+    a rdf:Property ;
+    rdfs:comment "A domain of the subject property." ;
+    rdfs:domain rdf:Property ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "domain" ;
+    rdfs:range rdfs:Class .
+
+rdfs:isDefinedBy
+    a rdf:Property ;
+    rdfs:comment "The defininition of the subject resource." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "isDefinedBy" ;
+    rdfs:range rdfs:Resource ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+rdfs:label
+    a rdf:Property ;
+    rdfs:comment "A human-readable name for the subject." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "label" ;
+    rdfs:range rdfs:Literal .
+
+rdfs:member
+    a rdf:Property ;
+    rdfs:comment "A member of the subject resource." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "member" ;
+    rdfs:range rdfs:Resource .
+
+rdfs:range
+    a rdf:Property ;
+    rdfs:comment "A range of the subject property." ;
+    rdfs:domain rdf:Property ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "range" ;
+    rdfs:range rdfs:Class .
+
+rdfs:seeAlso
+    a rdf:Property ;
+    rdfs:comment "Further information about the subject resource." ;
+    rdfs:domain rdfs:Resource ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "seeAlso" ;
+    rdfs:range rdfs:Resource .
+
+rdfs:subClassOf
+    a rdf:Property ;
+    rdfs:comment "The subject is a subclass of a class." ;
+    rdfs:domain rdfs:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "subClassOf" ;
+    rdfs:range rdfs:Class .
+
+rdfs:subPropertyOf
+    a rdf:Property ;
+    rdfs:comment "The subject is a subproperty of a property." ;
+    rdfs:domain rdf:Property ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    rdfs:label "subPropertyOf" ;
+    rdfs:range rdf:Property .
+

--- a/resources/shacl.ttl
+++ b/resources/shacl.ttl
@@ -1,0 +1,1462 @@
+# W3C Shapes Constraint Language (SHACL) Vocabulary
+# Draft last edited 2017-04-13
+
+@prefix owl:  <http://www.w3.org/2002/07/owl#> . 
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+
+sh:
+	a owl:Ontology ;
+	rdfs:label "W3C Shapes Constraint Language (SHACL) Vocabulary"@en ;
+	rdfs:comment "This vocabulary defines terms used in SHACL, the W3C Shapes Constraint Language."@en ;
+	sh:declare [
+		sh:prefix "sh" ;
+		sh:namespace "http://www.w3.org/ns/shacl#" ;
+	] ;
+	sh:suggestedShapesGraph <http://www.w3.org/ns/shacl-shacl#> .
+
+
+# Shapes vocabulary -----------------------------------------------------------
+
+sh:Shape
+	a rdfs:Class ;
+	rdfs:label "Shape"@en ;
+	rdfs:comment "A shape is a collection of constraints that may be targeted for certain nodes."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:NodeShape
+	a rdfs:Class ;
+	rdfs:label "Node shape"@en ;
+	rdfs:comment "A node shape is a shape that specifies constraint that need to be met with respect to focus nodes."@en ;
+	rdfs:subClassOf sh:Shape ;
+	rdfs:isDefinedBy sh: .
+
+sh:PropertyShape
+	a rdfs:Class ;
+	rdfs:label "Property shape"@en ;
+	rdfs:comment "A property shape is a shape that specifies constraints on the values of a focus node for a given property or path."@en ;
+	rdfs:subClassOf sh:Shape ;
+	rdfs:isDefinedBy sh: .
+
+sh:deactivated
+	a rdf:Property ;
+	rdfs:label "deactivated"@en ;
+	rdfs:comment "If set to true for a shape then the shape is deactivated and all nodes conform to it."@en ;
+	rdfs:domain sh:Shape ;
+	rdfs:range xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
+sh:target
+	a rdf:Property ;
+	rdfs:label "target"@en ;
+	rdfs:comment "Links a shape to a target specified by an extension language, for example instances of sh:SPARQLTarget."@en ;
+	rdfs:domain sh:Shape ;
+	rdfs:range sh:Target ;
+	rdfs:isDefinedBy sh: .
+
+sh:targetClass 
+	a rdf:Property ;
+	rdfs:label "target class"@en ;
+	rdfs:comment "Links a shape to a class, indicating that all instances of the class must conform to the shape."@en ;
+	rdfs:domain sh:Shape ;
+	rdfs:range rdfs:Class ;
+	rdfs:isDefinedBy sh: .
+
+sh:targetNode 
+	a rdf:Property ;
+	rdfs:label "target node"@en ;
+	rdfs:comment "Links a shape to individual nodes, indicating that these nodes must conform to the shape."@en ;
+	rdfs:domain sh:Shape ;
+	rdfs:isDefinedBy sh: .
+
+sh:targetObjectsOf
+	a rdf:Property ;
+	rdfs:label "target objects of"@en ;
+	rdfs:comment "Links a shape to a property, indicating that all all objects of triples that have the given property as their predicate must conform to the shape."@en ;
+	rdfs:domain sh:Shape ;
+	rdfs:range rdf:Property ;
+	rdfs:isDefinedBy sh: .
+
+sh:targetSubjectsOf
+	a rdf:Property ;
+	rdfs:label "target subjects of"@en ;
+	rdfs:comment "Links a shape to a property, indicating that all subjects of triples that have the given property as their predicate must conform to the shape."@en ;
+	rdfs:domain sh:Shape ;
+	rdfs:range rdf:Property ;
+	rdfs:isDefinedBy sh: .
+
+sh:message
+	a rdf:Property ;
+	# domain: sh:Shape or sh:SPARQLConstraint or sh:SPARQLSelectValidator or sh:SPARQLAskValidator
+	# range: xsd:string or rdf:langString
+	rdfs:label "message"@en ;
+	rdfs:comment "A human-readable message (possibly with placeholders for variables) explaining the cause of the result."@en ;
+	rdfs:isDefinedBy sh: .
+
+sh:severity
+	a rdf:Property ;
+	rdfs:label "severity"@en ;
+	rdfs:comment "Defines the severity that validation results produced by a shape must have. Defaults to sh:Violation."@en ;
+	rdfs:domain sh:Shape ;
+	rdfs:range sh:Severity ;
+	rdfs:isDefinedBy sh: .
+
+
+# Node kind vocabulary --------------------------------------------------------
+
+sh:NodeKind
+	a rdfs:Class ;
+	rdfs:label "Node kind"@en ;
+	rdfs:comment "The class of all node kinds, including sh:BlankNode, sh:IRI, sh:Literal or the combinations of these: sh:BlankNodeOrIRI, sh:BlankNodeOrLiteral, sh:IRIOrLiteral."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:BlankNode
+	a sh:NodeKind ;
+	rdfs:label "Blank node"@en ;
+	rdfs:comment "The node kind of all blank nodes."@en ;
+	rdfs:isDefinedBy sh: .
+
+sh:BlankNodeOrIRI
+	a sh:NodeKind ;
+	rdfs:label "Blank node or IRI"@en ;
+	rdfs:comment "The node kind of all blank nodes or IRIs."@en ;
+	rdfs:isDefinedBy sh: .
+
+sh:BlankNodeOrLiteral
+	a sh:NodeKind ;
+	rdfs:label "Blank node or literal"@en ;
+	rdfs:comment "The node kind of all blank nodes or literals."@en ;
+	rdfs:isDefinedBy sh: .
+
+sh:IRI
+	a sh:NodeKind ;
+	rdfs:label "IRI"@en ;
+	rdfs:comment "The node kind of all IRIs."@en ;
+	rdfs:isDefinedBy sh: .
+
+sh:IRIOrLiteral
+	a sh:NodeKind ;
+	rdfs:label "IRI or literal"@en ;
+	rdfs:comment "The node kind of all IRIs or literals."@en ;
+	rdfs:isDefinedBy sh: .
+
+sh:Literal
+	a sh:NodeKind ;
+	rdfs:label "Literal"@en ;
+	rdfs:comment "The node kind of all literals."@en ;
+	rdfs:isDefinedBy sh: .
+
+
+# Results vocabulary ----------------------------------------------------------
+
+sh:ValidationReport
+	a rdfs:Class ;
+	rdfs:label "Validation report"@en ;
+	rdfs:comment "The class of SHACL validation reports."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:conforms
+	a rdf:Property ;
+	rdfs:label "conforms"@en ;
+	rdfs:comment "True if the validation did not produce any validation results, and false otherwise."@en ;
+	rdfs:domain sh:ValidationReport ;
+	rdfs:range xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
+sh:result
+	a rdf:Property ;
+	rdfs:label "result"@en ;
+	rdfs:comment "The validation results contained in a validation report."@en ;
+	rdfs:domain sh:ValidationReport ;
+	rdfs:range sh:ValidationResult ;
+	rdfs:isDefinedBy sh: .
+
+sh:shapesGraphWellFormed
+	a rdf:Property ;
+	rdfs:label "shapes graph well-formed"@en ;
+	rdfs:comment "If true then the validation engine was certain that the shapes graph has passed all SHACL syntax requirements during the validation process."@en ;
+	rdfs:domain sh:ValidationReport ;
+	rdfs:range xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
+sh:AbstractResult
+	a rdfs:Class ;
+	rdfs:label "Abstract result"@en ;
+	rdfs:comment "The base class of validation results, typically not instantiated directly."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:ValidationResult
+	a rdfs:Class ;
+	rdfs:label "Validation result"@en ;
+	rdfs:comment "The class of validation results."@en ;
+	rdfs:subClassOf sh:AbstractResult ;
+	rdfs:isDefinedBy sh: .
+
+sh:Severity
+	a rdfs:Class ;
+	rdfs:label "Severity"@en ;
+	rdfs:comment "The class of validation result severity levels, including violation and warning levels."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:Info
+	a sh:Severity ;
+	rdfs:label "Info"@en ;
+	rdfs:comment "The severity for an informational validation result."@en ;
+	rdfs:isDefinedBy sh: .
+
+sh:Violation
+	a sh:Severity ;
+	rdfs:label "Violation"@en ;
+	rdfs:comment "The severity for a violation validation result."@en ;
+	rdfs:isDefinedBy sh: .
+
+sh:Warning
+	a sh:Severity ;
+	rdfs:label "Warning"@en ;
+	rdfs:comment "The severity for a warning validation result."@en ;
+	rdfs:isDefinedBy sh: .
+
+sh:detail
+	a rdf:Property ;
+	rdfs:label "detail"@en ;
+	rdfs:comment "Links a result with other results that provide more details, for example to describe violations against nested shapes."@en ;
+	rdfs:domain sh:AbstractResult ;
+	rdfs:range sh:AbstractResult ;
+	rdfs:isDefinedBy sh: .
+
+sh:focusNode
+	a rdf:Property ;
+	rdfs:label "focus node"@en ;
+	rdfs:comment "The focus node that was validated when the result was produced."@en ;
+	rdfs:domain sh:AbstractResult ;
+	rdfs:isDefinedBy sh: .
+
+sh:resultMessage
+	a rdf:Property ;
+	rdfs:label "result message"@en ;
+	rdfs:comment "Human-readable messages explaining the cause of the result."@en ;
+	rdfs:domain sh:AbstractResult ;
+	# range: xsd:string or rdf:langString
+	rdfs:isDefinedBy sh: .
+
+sh:resultPath
+	a rdf:Property ;
+	rdfs:label "result path"@en ;
+	rdfs:comment "The path of a validation result, based on the path of the validated property shape."@en ;
+	rdfs:domain sh:AbstractResult ;
+	rdfs:range rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:resultSeverity
+	a rdf:Property ;
+	rdfs:label "result severity"@en ;
+	rdfs:comment "The severity of the result, e.g. warning."@en ;
+	rdfs:domain sh:AbstractResult ;
+	rdfs:range sh:Severity ;
+	rdfs:isDefinedBy sh: .
+
+sh:sourceConstraint
+	a rdf:Property ;
+	rdfs:label "source constraint"@en ;
+	rdfs:comment "The constraint that was validated when the result was produced."@en ;
+	rdfs:domain sh:AbstractResult ;
+	# rdfs:range sh:SPARQLConstraint ;
+	rdfs:isDefinedBy sh: .
+
+sh:sourceShape
+	a rdf:Property ;
+	rdfs:label "source shape"@en ;
+	rdfs:comment "The shape that is was validated when the result was produced."@en ;
+	rdfs:domain sh:AbstractResult ;
+	rdfs:range sh:Shape ;
+	rdfs:isDefinedBy sh: .
+
+sh:sourceConstraintComponent
+	a rdf:Property ;
+	rdfs:label "source constraint component"@en ;
+	rdfs:comment "The constraint component that is the source of the result."@en ;
+	rdfs:domain sh:AbstractResult ;
+	rdfs:range sh:ConstraintComponent ;
+	rdfs:isDefinedBy sh: .
+
+sh:value
+	a rdf:Property ;
+	rdfs:label "value"@en ;
+	rdfs:comment "An RDF node that has caused the result."@en ;
+	rdfs:domain sh:AbstractResult ;
+	rdfs:isDefinedBy sh: .
+
+
+# SPARQL execution support ----------------------------------------------------
+
+sh:SPARQLExecutable
+	a rdfs:Class ;
+	rdfs:label "SPARQL executable"@en ;
+	rdfs:comment "The class of resources that encapsulate a SPARQL query."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLAskExecutable
+	a rdfs:Class ;
+	rdfs:label "SPARQL ASK executable"@en ;
+	rdfs:comment "The class of SPARQL executables that are based on an ASK query."@en ;
+	rdfs:subClassOf sh:SPARQLExecutable ;
+	rdfs:isDefinedBy sh: .
+
+sh:ask
+	a rdf:Property ;
+	rdfs:label "ask"@en ;
+	rdfs:comment "The SPARQL ASK query to execute."@en ;
+	rdfs:domain sh:SPARQLAskExecutable ;
+	rdfs:range xsd:string ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLConstructExecutable
+	a rdfs:Class ;
+	rdfs:label "SPARQL CONSTRUCT executable"@en ;
+	rdfs:comment "The class of SPARQL executables that are based on a CONSTRUCT query."@en ;
+	rdfs:subClassOf sh:SPARQLExecutable ;
+	rdfs:isDefinedBy sh: .
+
+sh:construct
+	a rdf:Property ;
+	rdfs:label "construct"@en ;
+	rdfs:comment "The SPARQL CONSTRUCT query to execute."@en ;
+	rdfs:domain sh:SPARQLConstructExecutable ;
+	rdfs:range xsd:string ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLSelectExecutable
+	a rdfs:Class ;
+	rdfs:label "SPARQL SELECT executable"@en ;
+	rdfs:comment "The class of SPARQL executables based on a SELECT query."@en ;
+	rdfs:subClassOf sh:SPARQLExecutable ;
+	rdfs:isDefinedBy sh: .
+
+sh:select
+	a rdf:Property ;
+	rdfs:label "select"@en ;
+	rdfs:comment "The SPARQL SELECT query to execute."@en ;
+	rdfs:range xsd:string ;
+	rdfs:domain sh:SPARQLSelectExecutable ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLUpdateExecutable
+	a rdfs:Class ;
+	rdfs:label "SPARQL UPDATE executable"@en ;
+	rdfs:comment "The class of SPARQL executables based on a SPARQL UPDATE."@en ;
+	rdfs:subClassOf sh:SPARQLExecutable ;
+	rdfs:isDefinedBy sh: .
+
+sh:update
+	a rdf:Property ;
+	rdfs:label "update"@en ;
+	rdfs:comment "The SPARQL UPDATE to execute."@en ;
+	rdfs:domain sh:SPARQLUpdateExecutable ;
+	rdfs:range xsd:string ;
+	rdfs:isDefinedBy sh: .
+
+sh:prefixes
+	a rdf:Property ;
+	rdfs:label "prefixes"@en ;
+	rdfs:comment "The prefixes that shall be applied before parsing the associated SPARQL query."@en ;
+	rdfs:domain sh:SPARQLExecutable ;
+	rdfs:range owl:Ontology ;
+	rdfs:isDefinedBy sh: .
+
+sh:PrefixDeclaration
+	a rdfs:Class ;
+	rdfs:label "Prefix declaration"@en ;
+	rdfs:comment "The class of prefix declarations, consisting of pairs of a prefix with a namespace."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:declare
+	a rdf:Property ;
+	rdfs:label "declare"@en ;
+	rdfs:comment "Links a resource with its namespace prefix declarations."@en ;
+	rdfs:domain owl:Ontology ;
+	rdfs:range sh:PrefixDeclaration ;
+	rdfs:isDefinedBy sh: .
+
+sh:prefix
+	a rdf:Property ;
+	rdfs:label "prefix"@en ;
+	rdfs:comment "The prefix of a prefix declaration."@en ;
+	rdfs:domain sh:PrefixDeclaration ;
+	rdfs:range xsd:string ;
+	rdfs:isDefinedBy sh: .
+
+sh:namespace
+	a rdf:Property ;
+	rdfs:label "namespace"@en ;
+	rdfs:comment "The namespace associated with a prefix in a prefix declaration."@en ;
+	rdfs:domain sh:PrefixDeclaration ;
+	rdfs:range xsd:anyURI ;
+	rdfs:isDefinedBy sh: .
+
+sh:shapesGraph
+	a rdf:Property ;
+	rdfs:label "shapes graph"@en ;
+	rdfs:comment "Shapes graphs that should be used when validating this data graph."@en ;
+	rdfs:domain owl:Ontology ;
+	rdfs:range owl:Ontology ;
+	rdfs:isDefinedBy sh: .
+
+sh:suggestedShapesGraph
+	a rdf:Property ;
+	rdfs:label "suggested shapes graph"@en ;
+	rdfs:comment "Suggested shapes graphs for this ontology. The values of this property may be used in the absence of specific sh:shapesGraph statements."@en ;
+	rdfs:domain owl:Ontology ;
+	rdfs:range owl:Ontology ;
+	rdfs:isDefinedBy sh: .
+		
+
+# Target vocabulary -----------------------------------------------------------
+
+sh:Target
+	a rdfs:Class ;
+	rdfs:label "Target"@en ;
+	rdfs:comment "The base class of targets such as those based on SPARQL queries."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLTarget
+	a rdfs:Class ;
+	rdfs:label "SPARQL target"@en ;
+	rdfs:comment "The class of targets that are based on SPARQL SELECT queries."@en ;
+	rdfs:subClassOf sh:Target ;
+	rdfs:subClassOf sh:SPARQLSelectExecutable ;
+	rdfs:isDefinedBy sh: .
+
+sh:TargetType
+	a rdfs:Class ;
+	rdfs:label "Target type"@en ;
+	rdfs:comment "The (meta) class for parameterizable targets.	Instances of this are instantiated as values of the sh:target property."@en ;
+	rdfs:subClassOf rdfs:Class ;
+	rdfs:subClassOf sh:Parameterizable ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLTargetType
+	a rdfs:Class ;
+	rdfs:label "SPARQL target type"@en ;
+	rdfs:comment "The (meta) class for parameterizable targets that are based on SPARQL SELECT queries."@en ;
+	rdfs:subClassOf sh:TargetType ;
+	rdfs:subClassOf sh:SPARQLSelectExecutable ;
+	rdfs:isDefinedBy sh: .
+
+
+# Path vocabulary -------------------------------------------------------------
+
+sh:path
+	a rdf:Property ;
+	rdfs:label "path"@en ;
+	rdfs:comment "Specifies the property path of a property shape."@en ;
+	rdfs:domain sh:PropertyShape ;
+	rdfs:range rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:inversePath
+	a rdf:Property ;
+	rdfs:label "inverse path"@en ;
+	rdfs:comment "The (single) value of this property represents an inverse path (object to subject)."@en ;
+	rdfs:range rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:alternativePath
+	a rdf:Property ;
+	rdfs:label "alternative path"@en ;
+	rdfs:comment "The (single) value of this property must be a list of path elements, representing the elements of alternative paths."@en ;
+	rdfs:range rdf:List ;
+	rdfs:isDefinedBy sh: .
+
+sh:zeroOrMorePath
+	a rdf:Property ;
+	rdfs:label "zero or more path"@en ;
+	rdfs:comment "The (single) value of this property represents a path that is matched zero or more times."@en ;
+	rdfs:range rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:oneOrMorePath
+	a rdf:Property ;
+	rdfs:label "one or more path"@en ;
+	rdfs:comment "The (single) value of this property represents a path that is matched one or more times."@en ;
+	rdfs:range rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:zeroOrOnePath
+	a rdf:Property ;
+	rdfs:label "zero or one path"@en ;
+	rdfs:comment "The (single) value of this property represents a path that is matched zero or one times."@en ;
+	rdfs:range rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+
+# Parameters metamodel --------------------------------------------------------
+
+sh:Parameterizable
+	a rdfs:Class ;
+	rdfs:label "Parameterizable"@en ;
+	rdfs:comment "Superclass of components that can take parameters, especially functions and constraint components."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:parameter
+	a rdf:Property ;
+	rdfs:label "parameter"@en ;
+	rdfs:comment "The parameters of a function or constraint component."@en ;
+	rdfs:domain sh:Parameterizable ;
+	rdfs:range sh:Parameter ;
+	rdfs:isDefinedBy sh: .
+
+sh:labelTemplate
+	a rdf:Property ;
+	rdfs:label "label template"@en ;
+	rdfs:comment "Outlines how human-readable labels of instances of the associated Parameterizable shall be produced. The values can contain {?paramName} as placeholders for the actual values of the given parameter."@en ;
+	rdfs:domain sh:Parameterizable ;
+	# range: xsd:string or rdf:langString
+	rdfs:isDefinedBy sh: .
+
+sh:Parameter
+	a rdfs:Class ;
+	rdfs:label "Parameter"@en ;
+	rdfs:comment "The class of parameter declarations, consisting of a path predicate and (possibly) information about allowed value type, cardinality and other characteristics."@en ;
+	rdfs:subClassOf sh:PropertyShape ;
+	rdfs:isDefinedBy sh: .
+
+sh:optional
+	a rdf:Property ;
+	rdfs:label "optional"@en ;
+	rdfs:comment "Indicates whether a parameter is optional."@en ;
+	rdfs:domain sh:Parameter ;
+	rdfs:range xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
+
+# Constraint components metamodel ---------------------------------------------
+
+sh:ConstraintComponent
+	a rdfs:Class ;
+	rdfs:label "Constraint component"@en ;
+	rdfs:comment "The class of constraint components."@en ;
+	rdfs:subClassOf sh:Parameterizable ;
+	rdfs:isDefinedBy sh: .
+
+sh:validator
+	a rdf:Property ;
+	rdfs:label "validator"@en ;
+	rdfs:comment "The validator(s) used to evaluate constraints of either node or property shapes."@en ;
+	rdfs:domain sh:ConstraintComponent ;
+	rdfs:range sh:Validator ;
+	rdfs:isDefinedBy sh: .
+
+sh:nodeValidator
+	a rdf:Property ;
+	rdfs:label "shape validator"@en ;
+	rdfs:comment "The validator(s) used to evaluate a constraint in the context of a node shape."@en ;
+	rdfs:domain sh:ConstraintComponent ;
+	rdfs:range sh:Validator ;
+	rdfs:isDefinedBy sh: .
+
+sh:propertyValidator
+	a rdf:Property ;
+	rdfs:label "property validator"@en ;
+	rdfs:comment "The validator(s) used to evaluate a constraint in the context of a property shape."@en ;
+	rdfs:domain sh:ConstraintComponent ;
+	rdfs:range sh:Validator ;
+	rdfs:isDefinedBy sh: .
+
+sh:Validator
+	a rdfs:Class ;
+	rdfs:label "Validator"@en ;
+	rdfs:comment "The class of validators, which provide instructions on how to process a constraint definition. This class serves as base class for the SPARQL-based validators and other possible implementations."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLAskValidator
+	a rdfs:Class ;
+	rdfs:label "SPARQL ASK validator"@en ;
+	rdfs:comment "The class of validators based on SPARQL ASK queries. The queries are evaluated for each value node and are supposed to return true if the given node conforms."@en ;
+	rdfs:subClassOf sh:Validator ;
+	rdfs:subClassOf sh:SPARQLAskExecutable ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLSelectValidator
+	a rdfs:Class ;
+	rdfs:label "SPARQL SELECT validator"@en ;
+	rdfs:comment "The class of validators based on SPARQL SELECT queries. The queries are evaluated for each focus node and are supposed to produce bindings for all focus nodes that do not conform."@en ;
+	rdfs:subClassOf sh:Validator ;
+	rdfs:subClassOf sh:SPARQLSelectExecutable ;
+	rdfs:isDefinedBy sh: .
+
+
+# Library of Core Constraint Components and their properties ------------------
+
+sh:AndConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "And constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to test whether a value node conforms to all members of a provided list of shapes."@en ;
+	sh:parameter sh:AndConstraintComponent-and ;
+	rdfs:isDefinedBy sh: .
+
+sh:AndConstraintComponent-and
+	a sh:Parameter ;
+	sh:path sh:and ;
+	rdfs:isDefinedBy sh: .
+
+sh:and
+	a rdf:Property ;
+	rdfs:label "and"@en ;
+	rdfs:comment "RDF list of shapes to validate the value nodes against."@en ;
+	rdfs:range rdf:List ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:ClassConstraintComponent 
+	a sh:ConstraintComponent ;
+	rdfs:label "Class constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that each value node is an instance of a given type."@en ;
+	sh:parameter sh:ClassConstraintComponent-class ;
+	rdfs:isDefinedBy sh: .
+
+sh:ClassConstraintComponent-class
+	a sh:Parameter ;
+	sh:path sh:class ;
+	sh:nodeKind sh:IRI ;
+	rdfs:isDefinedBy sh: .
+
+sh:class
+	a rdf:Property ;
+	rdfs:label "class"@en ;
+	rdfs:comment "The type that all value nodes must have."@en ;
+	rdfs:range rdfs:Class ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:ClosedConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Closed constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to indicate that focus nodes must only have values for those properties that have been explicitly enumerated via sh:property/sh:path."@en ;
+	sh:parameter sh:ClosedConstraintComponent-closed ;
+	sh:parameter sh:ClosedConstraintComponent-ignoredProperties ;
+	rdfs:isDefinedBy sh: .
+
+sh:ClosedConstraintComponent-closed
+	a sh:Parameter ; 
+	sh:path sh:closed ;
+	sh:datatype xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
+sh:ClosedConstraintComponent-ignoredProperties
+	a sh:Parameter ;
+	sh:path sh:ignoredProperties ;
+	sh:optional true ;
+	rdfs:isDefinedBy sh: .
+
+sh:closed
+	a rdf:Property ;
+	rdfs:label "closed"@en ;
+	rdfs:comment "If set to true then the shape is closed."@en ;
+	rdfs:range xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
+sh:ignoredProperties
+	a rdf:Property ;
+	rdfs:label "ignored properties"@en ;
+	rdfs:comment "An optional RDF list of properties that are also permitted in addition to those explicitly enumerated via sh:property/sh:path."@en ;
+	rdfs:range rdf:List ;    # members: rdf:Property
+	rdfs:isDefinedBy sh: .
+
+
+sh:DatatypeConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Datatype constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to restrict the datatype of all value nodes."@en ;
+	sh:parameter sh:DatatypeConstraintComponent-datatype ;
+	rdfs:isDefinedBy sh: .
+
+sh:DatatypeConstraintComponent-datatype
+	a sh:Parameter ;
+	sh:path sh:datatype ;
+	sh:nodeKind sh:IRI ;
+	sh:maxCount 1 ;
+	rdfs:isDefinedBy sh: .
+
+sh:datatype
+	a rdf:Property ;
+	rdfs:label "datatype"@en ;
+	rdfs:comment "Specifies an RDF datatype that all value nodes must have."@en ;
+	rdfs:range rdfs:Datatype ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:DisjointConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Disjoint constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that the set of value nodes is disjoint with the the set of nodes that have the focus node as subject and the value of a given property as predicate."@en ;
+	sh:parameter sh:DisjointConstraintComponent-disjoint ;
+	rdfs:isDefinedBy sh: .
+
+sh:DisjointConstraintComponent-disjoint
+	a sh:Parameter ;
+	sh:path sh:disjoint ;
+	sh:nodeKind sh:IRI ;
+	rdfs:isDefinedBy sh: .
+
+sh:disjoint
+	a rdf:Property ;
+	rdfs:label "disjoint"@en ;
+	rdfs:comment "Specifies a property where the set of values must be disjoint with the value nodes."@en ;
+	rdfs:range rdf:Property ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:EqualsConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Equals constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that the set of value nodes is equal to the set of nodes that have the focus node as subject and the value of a given property as predicate."@en ;
+	sh:parameter sh:EqualsConstraintComponent-equals ;
+	rdfs:isDefinedBy sh: .
+
+sh:EqualsConstraintComponent-equals
+	a sh:Parameter ;
+	sh:path sh:equals ;
+	sh:nodeKind sh:IRI ;
+	rdfs:isDefinedBy sh: .
+
+sh:equals
+	a rdf:Property ;
+	rdfs:label "equals"@en ;
+	rdfs:comment "Specifies a property that must have the same values as the value nodes."@en ;
+	rdfs:range rdf:Property ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:HasValueConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Has-value constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that one of the value nodes is a given RDF node."@en ;
+	sh:parameter sh:HasValueConstraintComponent-hasValue ;
+	rdfs:isDefinedBy sh: .
+
+sh:HasValueConstraintComponent-hasValue
+	a sh:Parameter ;
+	sh:path sh:hasValue ;
+	rdfs:isDefinedBy sh: .
+
+sh:hasValue
+	a rdf:Property ;
+	rdfs:label "has value"@en ;
+	rdfs:comment "Specifies a value that must be among the value nodes."@en ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:InConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "In constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to exclusively enumerate the permitted value nodes."@en ;
+	sh:parameter sh:InConstraintComponent-in ;
+	rdfs:isDefinedBy sh: .
+
+sh:InConstraintComponent-in
+	a sh:Parameter ;
+	sh:path sh:in ;
+	sh:maxCount 1 ;
+	rdfs:isDefinedBy sh: .
+
+sh:in
+	a rdf:Property ;
+	rdfs:label "in"@en ;
+	rdfs:comment "Specifies a list of allowed values so that each value node must be among the members of the given list."@en ;
+	rdfs:range rdf:List ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:LanguageInConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Language-in constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to enumerate language tags that all value nodes must have."@en ;
+	sh:parameter sh:LanguageInConstraintComponent-languageIn ;
+	rdfs:isDefinedBy sh: .
+
+sh:LanguageInConstraintComponent-languageIn
+	a sh:Parameter ;
+	sh:path sh:languageIn ;
+	sh:maxCount 1 ;
+	rdfs:isDefinedBy sh: .
+
+sh:languageIn
+	a rdf:Property ;
+	rdfs:label "language in"@en ;
+	rdfs:comment "Specifies a list of language tags that all value nodes must have."@en ;
+	rdfs:range rdf:List ;   # members: xsd:string
+	rdfs:isDefinedBy sh: .
+
+
+sh:LessThanConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Less-than constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that each value node is smaller than all the nodes that have the focus node as subject and the value of a given property as predicate."@en ;
+	sh:parameter sh:LessThanConstraintComponent-lessThan ;
+	rdfs:isDefinedBy sh: .
+
+sh:LessThanConstraintComponent-lessThan
+	a sh:Parameter ;
+	sh:path sh:lessThan ;
+	sh:nodeKind sh:IRI ;
+	rdfs:isDefinedBy sh: .
+
+sh:lessThan
+	a rdf:Property ;
+	rdfs:label "less than"@en ;
+	rdfs:comment "Specifies a property that must have smaller values than the value nodes."@en ;
+	rdfs:range rdf:Property ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:LessThanOrEqualsConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "less-than-or-equals constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that every value node is smaller than all the nodes that have the focus node as subject and the value of a given property as predicate."@en ;
+	sh:parameter sh:LessThanOrEqualsConstraintComponent-lessThanOrEquals ;
+	rdfs:isDefinedBy sh: .
+
+sh:LessThanOrEqualsConstraintComponent-lessThanOrEquals
+	a sh:Parameter ;
+	sh:path sh:lessThanOrEquals ;
+	sh:nodeKind sh:IRI ;
+	rdfs:isDefinedBy sh: .
+
+sh:lessThanOrEquals
+	a rdf:Property ;
+	rdfs:label "less than or equals"@en ;
+	rdfs:comment "Specifies a property that must have smaller or equal values than the value nodes."@en ;
+	rdfs:range rdf:Property ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:MaxCountConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Max-count constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to restrict the maximum number of value nodes."@en ;
+	sh:parameter sh:MaxCountConstraintComponent-maxCount ;
+	rdfs:isDefinedBy sh: .
+
+sh:MaxCountConstraintComponent-maxCount
+	a sh:Parameter ;
+	sh:path sh:maxCount ;
+	sh:datatype xsd:integer ;
+	sh:maxCount 1 ;
+	rdfs:isDefinedBy sh: .
+
+sh:maxCount
+	a rdf:Property ;
+	rdfs:label "max count"@en ;
+	rdfs:comment "Specifies the maximum number of values in the set of value nodes."@en ;
+	rdfs:range xsd:integer ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:MaxExclusiveConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Max-exclusive constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to restrict the range of value nodes with a maximum exclusive value."@en ;
+	sh:parameter sh:MaxExclusiveConstraintComponent-maxExclusive ;
+	rdfs:isDefinedBy sh: .
+
+sh:MaxExclusiveConstraintComponent-maxExclusive
+	a sh:Parameter ;
+	sh:path sh:maxExclusive ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	rdfs:isDefinedBy sh: .
+
+sh:maxExclusive
+	a rdf:Property ;
+	rdfs:label "max exclusive"@en ;
+	rdfs:comment "Specifies the maximum exclusive value of each value node."@en ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:MaxInclusiveConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Max-inclusive constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to restrict the range of value nodes with a maximum inclusive value."@en ;
+	sh:parameter sh:MaxInclusiveConstraintComponent-maxInclusive ;
+	rdfs:isDefinedBy sh: .
+
+sh:MaxInclusiveConstraintComponent-maxInclusive
+	a sh:Parameter ;
+	sh:path sh:maxInclusive ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	rdfs:isDefinedBy sh: .
+
+sh:maxInclusive
+	a rdf:Property ;
+	rdfs:label "max inclusive"@en ;
+	rdfs:comment "Specifies the maximum inclusive value of each value node."@en ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:MaxLengthConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Max-length constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to restrict the maximum string length of value nodes."@en ;
+	sh:parameter sh:MaxLengthConstraintComponent-maxLength ;
+	rdfs:isDefinedBy sh: .
+
+sh:MaxLengthConstraintComponent-maxLength
+	a sh:Parameter ;
+	sh:path sh:maxLength ;
+	sh:datatype xsd:integer ;
+	sh:maxCount 1 ;
+	rdfs:isDefinedBy sh: .
+
+sh:maxLength
+	a rdf:Property ;
+	rdfs:label "max length"@en ;
+	rdfs:comment "Specifies the maximum string length of each value node."@en ;
+	rdfs:range xsd:integer ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:MinCountConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Min-count constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to restrict the minimum number of value nodes."@en ;
+	sh:parameter sh:MinCountConstraintComponent-minCount ;
+	rdfs:isDefinedBy sh: .
+
+sh:MinCountConstraintComponent-minCount
+	a sh:Parameter ;
+	sh:path sh:minCount ;
+	sh:datatype xsd:integer ;
+	sh:maxCount 1 ;
+	rdfs:isDefinedBy sh: .
+
+sh:minCount
+	a rdf:Property ;
+	rdfs:label "min count"@en ;
+	rdfs:comment "Specifies the minimum number of values in the set of value nodes."@en ;
+	rdfs:range xsd:integer ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:MinExclusiveConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Min-exclusive constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to restrict the range of value nodes with a minimum exclusive value."@en ;
+	sh:parameter sh:MinExclusiveConstraintComponent-minExclusive ;
+	rdfs:isDefinedBy sh: .
+
+sh:MinExclusiveConstraintComponent-minExclusive
+	a sh:Parameter ;
+	sh:path sh:minExclusive ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	rdfs:isDefinedBy sh: .
+
+sh:minExclusive
+	a rdf:Property ;
+	rdfs:label "min exclusive"@en ;
+	rdfs:comment "Specifies the minimum exclusive value of each value node."@en ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:MinInclusiveConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Min-inclusive constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to restrict the range of value nodes with a minimum inclusive value."@en ;
+	sh:parameter sh:MinInclusiveConstraintComponent-minInclusive ;
+	rdfs:isDefinedBy sh: .
+
+sh:MinInclusiveConstraintComponent-minInclusive
+	a sh:Parameter ;
+	sh:path sh:minInclusive ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	rdfs:isDefinedBy sh: .
+
+sh:minInclusive
+	a rdf:Property ;
+	rdfs:label "min inclusive"@en ;
+	rdfs:comment "Specifies the minimum inclusive value of each value node."@en ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:MinLengthConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Min-length constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to restrict the minimum string length of value nodes."@en ;
+	sh:parameter sh:MinLengthConstraintComponent-minLength ;
+	rdfs:isDefinedBy sh: .
+
+sh:MinLengthConstraintComponent-minLength
+	a sh:Parameter ;
+	sh:path sh:minLength ;
+	sh:datatype xsd:integer ;
+	sh:maxCount 1 ;
+	rdfs:isDefinedBy sh: .
+
+sh:minLength
+	a rdf:Property ;
+	rdfs:label "min length"@en ;
+	rdfs:comment "Specifies the minimum string length of each value node."@en ;
+	rdfs:range xsd:integer ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:NodeConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Node constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that all value nodes conform to the given node shape."@en ;
+	sh:parameter sh:NodeConstraintComponent-node ;
+	rdfs:isDefinedBy sh: .
+
+sh:NodeConstraintComponent-node
+	a sh:Parameter ;
+	sh:path sh:node ;
+	rdfs:isDefinedBy sh: .
+
+sh:node
+	a rdf:Property ;
+	rdfs:label "node"@en ;
+	rdfs:comment "Specifies the node shape that all value nodes must conform to."@en ;
+	rdfs:range sh:NodeShape ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:NodeKindConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Node-kind constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to restrict the RDF node kind of each value node."@en ;
+	sh:parameter sh:NodeKindConstraintComponent-nodeKind ;
+	rdfs:isDefinedBy sh: .
+
+sh:NodeKindConstraintComponent-nodeKind
+	a sh:Parameter ;
+	sh:path sh:nodeKind ;
+	sh:in ( sh:BlankNode sh:IRI sh:Literal sh:BlankNodeOrIRI sh:BlankNodeOrLiteral sh:IRIOrLiteral ) ;
+	sh:maxCount 1 ;
+	rdfs:isDefinedBy sh: .
+
+sh:nodeKind
+	a rdf:Property ;
+	rdfs:label "node kind"@en ;
+	rdfs:comment "Specifies the node kind (e.g. IRI or literal) each value node."@en ;
+	rdfs:range sh:NodeKind ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:NotConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Not constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that value nodes do not conform to a given shape."@en ;
+	sh:parameter sh:NotConstraintComponent-not ;
+	rdfs:isDefinedBy sh: .
+
+sh:NotConstraintComponent-not
+	a sh:Parameter ;
+	sh:path sh:not ;
+	rdfs:isDefinedBy sh: .
+
+sh:not
+	a rdf:Property ;
+	rdfs:label "not"@en ;
+	rdfs:comment "Specifies a shape that the value nodes must not conform to."@en ;
+	rdfs:range sh:Shape ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:OrConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Or constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to restrict the value nodes so that they conform to at least one out of several provided shapes."@en ;
+	sh:parameter sh:OrConstraintComponent-or ;
+	rdfs:isDefinedBy sh: .
+
+sh:OrConstraintComponent-or
+	a sh:Parameter ;
+	sh:path sh:or ;
+	rdfs:isDefinedBy sh: .
+
+sh:or
+	a rdf:Property ;
+	rdfs:label "or"@en ;
+	rdfs:comment "Specifies a list of shapes so that the value nodes must conform to at least one of the shapes."@en ;
+	rdfs:range rdf:List ;    # members: sh:Shape ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:PatternConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Pattern constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that every value node matches a given regular expression."@en ;
+	sh:parameter sh:PatternConstraintComponent-pattern ;
+	sh:parameter sh:PatternConstraintComponent-flags ;
+	rdfs:isDefinedBy sh: .
+
+sh:PatternConstraintComponent-pattern
+	a sh:Parameter ;
+	sh:path sh:pattern ;
+	sh:datatype xsd:string ;
+	rdfs:isDefinedBy sh: .
+
+sh:PatternConstraintComponent-flags
+	a sh:Parameter ;
+	sh:path sh:flags ;
+	sh:datatype xsd:string ;
+	sh:optional true ;
+	rdfs:isDefinedBy sh: .
+
+sh:flags
+	a rdf:Property ;
+	rdfs:label "flags"@en ;
+	rdfs:comment "An optional flag to be used with regular expression pattern matching."@en ;
+	rdfs:range xsd:string ;
+	rdfs:isDefinedBy sh: .
+
+sh:pattern
+	a rdf:Property ;
+	rdfs:label "pattern"@en ;
+	rdfs:comment "Specifies a regular expression pattern that the string representations of the value nodes must match."@en ;
+	rdfs:range xsd:string ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:PropertyConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Property constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that all value nodes conform to the given property shape."@en ;
+	sh:parameter sh:PropertyConstraintComponent-property ;
+	rdfs:isDefinedBy sh: .
+
+sh:PropertyConstraintComponent-property
+	a sh:Parameter ;
+	sh:path sh:property ;
+	rdfs:isDefinedBy sh: .
+
+sh:property
+	a rdf:Property ;
+	rdfs:label "property"@en ;
+	rdfs:comment "Links a shape to its property shapes."@en ;
+	rdfs:domain sh:Shape ;
+	rdfs:range sh:PropertyShape ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:QualifiedMaxCountConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Qualified-max-count constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that a specified maximum number of value nodes conforms to a given shape."@en ;
+	sh:parameter sh:QualifiedMaxCountConstraintComponent-qualifiedMaxCount ;
+	sh:parameter sh:QualifiedMaxCountConstraintComponent-qualifiedValueShape ;
+	sh:parameter sh:QualifiedMaxCountConstraintComponent-qualifiedValueShapesDisjoint ;
+	rdfs:isDefinedBy sh: .
+
+sh:QualifiedMaxCountConstraintComponent-qualifiedMaxCount
+	a sh:Parameter ;
+	sh:path sh:qualifiedMaxCount ;
+	sh:datatype xsd:integer ;
+	rdfs:isDefinedBy sh: .
+
+sh:QualifiedMaxCountConstraintComponent-qualifiedValueShape
+	a sh:Parameter ;
+	sh:path sh:qualifiedValueShape ;
+	rdfs:isDefinedBy sh: .
+
+sh:QualifiedMaxCountConstraintComponent-qualifiedValueShapesDisjoint
+	a sh:Parameter ;
+	sh:path sh:qualifiedValueShapesDisjoint ;
+	sh:datatype xsd:boolean ;
+	sh:optional true ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:QualifiedMinCountConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Qualified-min-count constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to verify that a specified minimum number of value nodes conforms to a given shape."@en ;
+	sh:parameter sh:QualifiedMinCountConstraintComponent-qualifiedMinCount ;
+	sh:parameter sh:QualifiedMinCountConstraintComponent-qualifiedValueShape ;
+	sh:parameter sh:QualifiedMinCountConstraintComponent-qualifiedValueShapesDisjoint ;
+	rdfs:isDefinedBy sh: .
+
+sh:QualifiedMinCountConstraintComponent-qualifiedMinCount
+	a sh:Parameter ;
+	sh:path sh:qualifiedMinCount ;
+	sh:datatype xsd:integer ;
+	rdfs:isDefinedBy sh: .
+
+sh:QualifiedMinCountConstraintComponent-qualifiedValueShape
+	a sh:Parameter ;
+	sh:path sh:qualifiedValueShape ;
+	rdfs:isDefinedBy sh: .
+
+sh:QualifiedMinCountConstraintComponent-qualifiedValueShapesDisjoint
+	a sh:Parameter ;
+	sh:path sh:qualifiedValueShapesDisjoint ;
+	sh:datatype xsd:boolean ;
+	sh:optional true ;
+	rdfs:isDefinedBy sh: .
+
+sh:qualifiedMaxCount
+	a rdf:Property ;
+	rdfs:label "qualified max count"@en ;
+	rdfs:comment "The maximum number of value nodes that can conform to the shape."@en ;
+	rdfs:range xsd:integer ;
+	rdfs:isDefinedBy sh: .
+
+sh:qualifiedMinCount
+	a rdf:Property ;
+	rdfs:label "qualified min count"@en ;
+	rdfs:comment "The minimum number of value nodes that must conform to the shape."@en ;
+	rdfs:range xsd:integer ;
+	rdfs:isDefinedBy sh: .
+
+sh:qualifiedValueShape
+	a rdf:Property ;
+	rdfs:label "qualified value shape"@en ;
+	rdfs:comment "The shape that a specified number of values must conform to."@en ;
+	rdfs:range sh:Shape ;
+	rdfs:isDefinedBy sh: .
+	
+sh:qualifiedValueShapesDisjoint
+	a rdf:Property ;
+	rdfs:label "qualified value shapes disjoint"@en ;
+	rdfs:comment "Can be used to mark the qualified value shape to be disjoint with its sibling shapes."@en ;
+	rdfs:range xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:UniqueLangConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Unique-languages constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to specify that no pair of value nodes may use the same language tag."@en ;
+	sh:parameter sh:UniqueLangConstraintComponent-uniqueLang ;
+	rdfs:isDefinedBy sh: .
+
+sh:UniqueLangConstraintComponent-uniqueLang
+	a sh:Parameter ;
+	sh:path sh:uniqueLang ;
+	sh:datatype xsd:boolean ;
+	sh:maxCount 1 ;
+	rdfs:isDefinedBy sh: .
+
+sh:uniqueLang
+	a rdf:Property ;
+	rdfs:label "unique languages"@en ;
+	rdfs:comment "Specifies whether all node values must have a unique (or no) language tag."@en ;
+	rdfs:range xsd:boolean ;
+	rdfs:isDefinedBy sh: .
+
+
+sh:XoneConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Exactly one constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to restrict the value nodes so that they conform to exactly one out of several provided shapes."@en ;
+	sh:parameter sh:XoneConstraintComponent-xone ;
+	rdfs:isDefinedBy sh: .
+
+sh:XoneConstraintComponent-xone
+	a sh:Parameter ;
+	sh:path sh:xone ;
+	rdfs:isDefinedBy sh: .
+
+sh:xone
+	a rdf:Property ;
+	rdfs:label "exactly one"@en ;
+	rdfs:comment "Specifies a list of shapes so that the value nodes must conform to exactly one of the shapes."@en ;
+	rdfs:range rdf:List ;    # members: sh:Shape ;
+	rdfs:isDefinedBy sh: .
+	
+
+# SPARQL-based Constraints support --------------------------------------------
+
+sh:SPARQLConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "SPARQL constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to define constraints based on SPARQL queries."@en ;
+	sh:parameter sh:SPARQLConstraintComponent-sparql ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLConstraintComponent-sparql
+	a sh:Parameter ;
+	sh:path sh:sparql ;
+	rdfs:isDefinedBy sh: .
+
+sh:sparql
+	a rdf:Property ;
+	rdfs:label "constraint (in SPARQL)"@en ;
+	rdfs:comment "Links a shape with SPARQL constraints."@en ;
+	rdfs:domain sh:Shape ;
+	rdfs:range sh:SPARQLConstraint ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLConstraint
+	a rdfs:Class ;
+	rdfs:label "SPARQL constraint"@en ;
+	rdfs:comment "The class of constraints based on SPARQL SELECT queries."@en ;
+	rdfs:subClassOf sh:SPARQLSelectExecutable ;
+	rdfs:isDefinedBy sh: .
+
+
+# Derived Values support ------------------------------------------------------
+
+sh:DerivedValuesConstraintComponent
+	a sh:ConstraintComponent ;
+	rdfs:label "Derived-values constraint component"@en ;
+	rdfs:comment "A constraint component that can be used to state that the set of value nodes must be equivalent to a set of values derived using a given mechanism, such as a SPARQL query."@en ;
+	sh:parameter [
+		sh:path sh:derivedValues ;
+		sh:class sh:ValuesDeriver ;
+	] ;
+	rdfs:isDefinedBy sh: .
+
+sh:derivedValues
+	a rdf:Property ;
+	rdfs:label "derived values"@en ;
+	rdfs:comment "Links a constraint with a sh:ValuesDeriver used to compute the property values."@en ;
+	rdfs:range sh:ValuesDeriver ;
+	rdfs:isDefinedBy sh: .
+
+sh:ValuesDeriver
+	a rdfs:Class ;
+	rdfs:label "Values deriver"@en ;
+	rdfs:comment "The class of objects that can be used to derive values. SHACL itself only defines a single subclass, sh:SPARQLValuesDeriver."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLValuesDeriver
+	a rdfs:Class ;
+	rdfs:label "SPARQL values deriver"@en ;
+	rdfs:comment "The class of objects that can be used to derive values based on a SPARQL SELECT query."@en ;
+	rdfs:subClassOf sh:ValuesDeriver ;
+	rdfs:subClassOf sh:SPARQLSelectExecutable ;
+	rdfs:isDefinedBy sh: .
+
+
+# Non-validating constraint properties ----------------------------------------
+
+sh:defaultValue
+	a rdf:Property ;
+	rdfs:label "default value"@en ;
+	rdfs:comment "A default value for a property, for example for user interface tools to pre-populate input fields."@en ;
+	rdfs:domain sh:PropertyShape ;
+	rdfs:isDefinedBy sh: .
+
+sh:description
+	a rdf:Property ;
+	rdfs:label "description"@en ;
+	rdfs:comment "Human-readable descriptions for the property in the context of the surrounding shape."@en ;
+	rdfs:domain sh:PropertyShape ;
+	# range: xsd:string or rdf:langString
+	rdfs:isDefinedBy sh: .
+
+sh:group
+	a rdf:Property ;
+	rdfs:label "group"@en ;
+	rdfs:comment "Can be used to link to a property group to indicate that a property shape belongs to a group of related property shapes."@en ;
+	rdfs:domain sh:PropertyShape ;
+	rdfs:range sh:PropertyGroup ;
+	rdfs:isDefinedBy sh: .
+
+sh:name
+	a rdf:Property ;
+	rdfs:label "name"@en ;
+	rdfs:comment "Human-readable labels for the property in the context of the surrounding shape."@en ;
+	rdfs:domain sh:PropertyShape ;
+	# range: xsd:string or rdf:langString
+	rdfs:isDefinedBy sh: .
+
+sh:order
+	a rdf:Property ;
+	rdfs:label "order"@en ;
+	rdfs:comment "Specifies the relative order of this compared to its siblings. For example use 0 for the first, 1 for the second."@en ;
+	# domain: sh:PropertyShape or sh:PropertyGroup
+	# range: xsd:decimal or xsd:integer ;
+	rdfs:isDefinedBy sh: .
+
+sh:PropertyGroup
+	a rdfs:Class ;
+	rdfs:label "Property group"@en ;
+	rdfs:comment "Instances of this class represent groups of property shapes that belong together."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+
+# Functions Vocabulary --------------------------------------------------------
+
+sh:Function
+	a rdfs:Class ;
+	rdfs:label "Function"@en ;
+	rdfs:comment "The class of SHACL functions."@en ;
+	rdfs:subClassOf sh:Parameterizable ;
+	rdfs:isDefinedBy sh: .
+
+sh:returnType
+	a rdf:Property ;
+	rdfs:label "return type"@en ;
+	rdfs:comment "The expected type of values returned by the associated function."@en ;
+	rdfs:domain sh:Function ;
+	rdfs:range rdfs:Class ;
+	rdfs:isDefinedBy sh: .
+
+sh:SPARQLFunction
+	a rdfs:Class ;
+	rdfs:label "SPARQL function"@en ;
+	rdfs:comment "A function backed by a SPARQL query - either ASK or SELECT."@en ;
+	rdfs:subClassOf sh:Function ;
+	rdfs:subClassOf sh:SPARQLAskExecutable ;
+	rdfs:subClassOf sh:SPARQLSelectExecutable ;
+	rdfs:isDefinedBy sh: .
+
+
+# Result Annotations ----------------------------------------------------------
+
+sh:resultAnnotation
+	a rdf:Property ;
+	rdfs:label "result annotation"@en ;
+	rdfs:comment "Links a SPARQL validator with zero or more sh:ResultAnnotation instances, defining how to derive additional result properties based on the variables of the SELECT query."@en ;
+	rdfs:domain sh:SPARQLSelectValidator ;
+	rdfs:range sh:ResultAnnotation ;
+	rdfs:isDefinedBy sh: .
+
+sh:ResultAnnotation
+	a rdfs:Class ;
+	rdfs:label "Result annotation"@en ;
+	rdfs:comment "A class of result annotations, which define the rules to derive the values of a given annotation property as extra values for a validation result."@en ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy sh: .
+
+sh:annotationProperty
+	a rdf:Property ;
+	rdfs:label "annotation property"@en ;
+	rdfs:comment "The annotation property that shall be set."@en ;
+	rdfs:domain sh:ResultAnnotation ;
+	rdfs:range rdf:Property ;
+	rdfs:isDefinedBy sh: .
+
+sh:annotationValue
+	a rdf:Property ;
+	rdfs:label "annotation value"@en ;
+	rdfs:comment "The (default) values of the annotation property."@en ;
+	rdfs:domain sh:ResultAnnotation ;
+	rdfs:isDefinedBy sh: .
+
+sh:annotationVarName
+	a rdf:Property ;
+	rdfs:label "annotation variable name"@en ;
+	rdfs:comment "The name of the SPARQL variable from the SELECT clause that shall be used for the values."@en ;
+	rdfs:domain sh:ResultAnnotation ;
+	rdfs:range xsd:string ;
+	rdfs:isDefinedBy sh: .

--- a/resources/skos.ttl
+++ b/resources/skos.ttl
@@ -1,0 +1,278 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<http://www.w3.org/2004/02/skos/core>
+  a owl:Ontology ;
+  dc:title "SKOS Vocabulary"@en ;
+  dc:contributor "Dave Beckett", "Nikki Rogers", "Participants in W3C's Semantic Web Deployment Working Group." ;
+  dc:description "An RDF vocabulary for describing the basic structure and content of concept schemes such as thesauri, classification schemes, subject heading lists, taxonomies, 'folksonomies', other types of controlled vocabulary, and also concept schemes embedded in glossaries and terminologies."@en ;
+  dc:creator "Alistair Miles", "Sean Bechhofer" ;
+  rdfs:seeAlso <http://www.w3.org/TR/skos-reference/> .
+
+skos:Concept
+  rdfs:label "Concept"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "An idea or notion; a unit of thought."@en ;
+  a owl:Class .
+
+skos:ConceptScheme
+  rdfs:label "Concept Scheme"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "A set of concepts, optionally including statements about semantic relationships between those concepts."@en ;
+  skos:scopeNote "A concept scheme may be defined to include concepts from different sources."@en ;
+  skos:example "Thesauri, classification schemes, subject heading lists, taxonomies, 'folksonomies', and other types of controlled vocabulary are all examples of concept schemes. Concept schemes are also embedded in glossaries and terminologies."@en ;
+  a owl:Class ;
+  owl:disjointWith skos:Concept .
+
+skos:Collection
+  rdfs:label "Collection"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "A meaningful collection of concepts."@en ;
+  skos:scopeNote "Labelled collections can be used where you would like a set of concepts to be displayed under a 'node label' in the hierarchy."@en ;
+  a owl:Class ;
+  owl:disjointWith skos:Concept, skos:ConceptScheme .
+
+skos:OrderedCollection
+  rdfs:label "Ordered Collection"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "An ordered collection of concepts, where both the grouping and the ordering are meaningful."@en ;
+  skos:scopeNote "Ordered collections can be used where you would like a set of concepts to be displayed in a specific order, and optionally under a 'node label'."@en ;
+  a owl:Class ;
+  rdfs:subClassOf skos:Collection .
+
+skos:inScheme
+  rdfs:label "is in scheme"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "Relates a resource (for example a concept) to a concept scheme in which it is included."@en ;
+  skos:scopeNote "A concept may be a member of more than one concept scheme."@en ;
+  a owl:ObjectProperty, rdf:Property ;
+  rdfs:range skos:ConceptScheme .
+
+skos:hasTopConcept
+  rdfs:label "has top concept"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "Relates, by convention, a concept scheme to a concept which is topmost in the broader/narrower concept hierarchies for that scheme, providing an entry point to these hierarchies."@en ;
+  a owl:ObjectProperty, rdf:Property ;
+  rdfs:domain skos:ConceptScheme ;
+  rdfs:range skos:Concept ;
+  owl:inverseOf skos:topConceptOf .
+
+skos:topConceptOf
+  rdfs:label "is top concept in scheme"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "Relates a concept to the concept scheme that it is a top level concept of."@en ;
+  a owl:ObjectProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:inScheme ;
+  owl:inverseOf skos:hasTopConcept ;
+  rdfs:domain skos:Concept ;
+  rdfs:range skos:ConceptScheme .
+
+skos:prefLabel
+  rdfs:label "preferred label"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "The preferred lexical label for a resource, in a given language."@en ;
+  a owl:AnnotationProperty, rdf:Property ;
+  rdfs:subPropertyOf rdfs:label ;
+  rdfs:comment "A resource has no more than one value of skos:prefLabel per language tag, and no more than one value of skos:prefLabel without language tag."@en, "The range of skos:prefLabel is the class of RDF plain literals."@en, """skos:prefLabel, skos:altLabel and skos:hiddenLabel are pairwise
+      disjoint properties."""@en .
+
+skos:altLabel
+  rdfs:label "alternative label"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "An alternative lexical label for a resource."@en ;
+  skos:example "Acronyms, abbreviations, spelling variants, and irregular plural/singular forms may be included among the alternative labels for a concept. Mis-spelled terms are normally included as hidden labels (see skos:hiddenLabel)."@en ;
+  a owl:AnnotationProperty, rdf:Property ;
+  rdfs:subPropertyOf rdfs:label ;
+  rdfs:comment "The range of skos:altLabel is the class of RDF plain literals."@en, "skos:prefLabel, skos:altLabel and skos:hiddenLabel are pairwise disjoint properties."@en .
+
+skos:hiddenLabel
+  rdfs:label "hidden label"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "A lexical label for a resource that should be hidden when generating visual displays of the resource, but should still be accessible to free text search operations."@en ;
+  a owl:AnnotationProperty, rdf:Property ;
+  rdfs:subPropertyOf rdfs:label ;
+  rdfs:comment "The range of skos:hiddenLabel is the class of RDF plain literals."@en, "skos:prefLabel, skos:altLabel and skos:hiddenLabel are pairwise disjoint properties."@en .
+
+skos:notation
+  rdfs:label "notation"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "A notation, also known as classification code, is a string of characters such as \"T58.5\" or \"303.4833\" used to uniquely identify a concept within the scope of a given concept scheme."@en ;
+  skos:scopeNote "By convention, skos:notation is used with a typed literal in the object position of the triple."@en ;
+  a owl:DatatypeProperty, rdf:Property .
+
+skos:note
+  rdfs:label "note"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "A general note, for any purpose."@en ;
+  skos:scopeNote "This property may be used directly, or as a super-property for more specific note types."@en ;
+  a owl:AnnotationProperty, rdf:Property .
+
+skos:changeNote
+  rdfs:label "change note"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "A note about a modification to a concept."@en ;
+  a owl:AnnotationProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:note .
+
+skos:definition
+  rdfs:label "definition"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "A statement or formal explanation of the meaning of a concept."@en ;
+  a owl:AnnotationProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:note .
+
+skos:editorialNote
+  rdfs:label "editorial note"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "A note for an editor, translator or maintainer of the vocabulary."@en ;
+  a owl:AnnotationProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:note .
+
+skos:example
+  rdfs:label "example"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "An example of the use of a concept."@en ;
+  a owl:AnnotationProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:note .
+
+skos:historyNote
+  rdfs:label "history note"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "A note about the past state/use/meaning of a concept."@en ;
+  a owl:AnnotationProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:note .
+
+skos:scopeNote
+  rdfs:label "scope note"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "A note that helps to clarify the meaning and/or the use of a concept."@en ;
+  a owl:AnnotationProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:note .
+
+skos:semanticRelation
+  rdfs:label "is in semantic relation with"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "Links a concept to a concept related by meaning."@en ;
+  skos:scopeNote "This property should not be used directly, but as a super-property for all properties denoting a relationship of meaning between concepts."@en ;
+  a owl:ObjectProperty, rdf:Property ;
+  rdfs:domain skos:Concept ;
+  rdfs:range skos:Concept .
+
+skos:broader
+  rdfs:label "has broader"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "Relates a concept to a concept that is more general in meaning."@en ;
+  rdfs:comment "Broader concepts are typically rendered as parents in a concept hierarchy (tree)."@en ;
+  skos:scopeNote "By convention, skos:broader is only used to assert an immediate (i.e. direct) hierarchical link between two conceptual resources."@en ;
+  a owl:ObjectProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:broaderTransitive ;
+  owl:inverseOf skos:narrower .
+
+skos:narrower
+  rdfs:label "has narrower"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "Relates a concept to a concept that is more specific in meaning."@en ;
+  skos:scopeNote "By convention, skos:broader is only used to assert an immediate (i.e. direct) hierarchical link between two conceptual resources."@en ;
+  rdfs:comment "Narrower concepts are typically rendered as children in a concept hierarchy (tree)."@en ;
+  a owl:ObjectProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:narrowerTransitive ;
+  owl:inverseOf skos:broader .
+
+skos:related
+  rdfs:label "has related"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "Relates a concept to a concept with which there is an associative semantic relationship."@en ;
+  a owl:ObjectProperty, owl:SymmetricProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:semanticRelation ;
+  rdfs:comment "skos:related is disjoint with skos:broaderTransitive"@en .
+
+skos:broaderTransitive
+  rdfs:label "has broader transitive"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "skos:broaderTransitive is a transitive superproperty of skos:broader." ;
+  skos:scopeNote "By convention, skos:broaderTransitive is not used to make assertions. Rather, the properties can be used to draw inferences about the transitive closure of the hierarchical relation, which is useful e.g. when implementing a simple query expansion algorithm in a search application."@en ;
+  a owl:ObjectProperty, owl:TransitiveProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:semanticRelation ;
+  owl:inverseOf skos:narrowerTransitive .
+
+skos:narrowerTransitive
+  rdfs:label "has narrower transitive"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "skos:narrowerTransitive is a transitive superproperty of skos:narrower." ;
+  skos:scopeNote "By convention, skos:narrowerTransitive is not used to make assertions. Rather, the properties can be used to draw inferences about the transitive closure of the hierarchical relation, which is useful e.g. when implementing a simple query expansion algorithm in a search application."@en ;
+  a owl:ObjectProperty, owl:TransitiveProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:semanticRelation ;
+  owl:inverseOf skos:broaderTransitive .
+
+skos:member
+  rdfs:label "has member"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "Relates a collection to one of its members."@en ;
+  a owl:ObjectProperty, rdf:Property ;
+  rdfs:domain skos:Collection ;
+  rdfs:range [
+    a owl:Class ;
+    owl:unionOf (
+     skos:Concept
+     skos:Collection
+   )
+  ] .
+
+skos:memberList
+  rdfs:label "has member list"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "Relates an ordered collection to the RDF list containing its members."@en ;
+  a owl:ObjectProperty, owl:FunctionalProperty, rdf:Property ;
+  rdfs:domain skos:OrderedCollection ;
+  rdfs:range rdf:List ;
+  rdfs:comment """For any resource, every item in the list given as the value of the
+      skos:memberList property is also a value of the skos:member property."""@en .
+
+skos:mappingRelation
+  rdfs:label "is in mapping relation with"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "Relates two concepts coming, by convention, from different schemes, and that have comparable meanings"@en ;
+  rdfs:comment "These concept mapping relations mirror semantic relations, and the data model defined below is similar (with the exception of skos:exactMatch) to the data model defined for semantic relations. A distinct vocabulary is provided for concept mapping relations, to provide a convenient way to differentiate links within a concept scheme from links between concept schemes. However, this pattern of usage is not a formal requirement of the SKOS data model, and relies on informal definitions of best practice."@en ;
+  a owl:ObjectProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:semanticRelation .
+
+skos:broadMatch
+  rdfs:label "has broader match"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "skos:broadMatch is used to state a hierarchical mapping link between two conceptual resources in different concept schemes."@en ;
+  a owl:ObjectProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:mappingRelation, skos:broader ;
+  owl:inverseOf skos:narrowMatch .
+
+skos:narrowMatch
+  rdfs:label "has narrower match"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "skos:narrowMatch is used to state a hierarchical mapping link between two conceptual resources in different concept schemes."@en ;
+  a owl:ObjectProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:mappingRelation, skos:narrower ;
+  owl:inverseOf skos:broadMatch .
+
+skos:relatedMatch
+  rdfs:label "has related match"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "skos:relatedMatch is used to state an associative mapping link between two conceptual resources in different concept schemes."@en ;
+  a owl:ObjectProperty, owl:SymmetricProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:mappingRelation, skos:related .
+
+skos:exactMatch
+  rdfs:label "has exact match"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "skos:exactMatch is used to link two concepts, indicating a high degree of confidence that the concepts can be used interchangeably across a wide range of information retrieval applications. skos:exactMatch is a transitive property, and is a sub-property of skos:closeMatch."@en ;
+  a owl:ObjectProperty, owl:SymmetricProperty, owl:TransitiveProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:closeMatch ;
+  rdfs:comment "skos:exactMatch is disjoint with each of the properties skos:broadMatch and skos:relatedMatch."@en .
+
+skos:closeMatch
+  rdfs:label "has close match"@en ;
+  rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+  skos:definition "skos:closeMatch is used to link two concepts that are sufficiently similar that they can be used interchangeably in some information retrieval applications. In order to avoid the possibility of \"compound errors\" when combining mappings across more than two concept schemes, skos:closeMatch is not declared to be a transitive property."@en ;
+  a owl:ObjectProperty, owl:SymmetricProperty, rdf:Property ;
+  rdfs:subPropertyOf skos:mappingRelation .

--- a/resources/vann.ttl
+++ b/resources/vann.ttl
@@ -1,0 +1,82 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+
+<http://iandavis.com/id/me>
+    a foaf:Person ;
+    foaf:name "Ian Davis" .
+
+<http://purl.org/vocab/vann/>
+    dct:creator <http://iandavis.com/id/me> ;
+    dct:date "2010-06-07" ;
+    dct:description "This document describes a vocabulary for annotating descriptions of vocabularies with examples and usage notes."@en ;
+    dct:identifier "http://purl.org/vocab/vann/vann-vocab-20050401" ;
+    dct:isVersionOf <http://purl.org/vocab/vann/> ;
+    dct:rights "Copyright © 2005 Ian Davis" ;
+    dct:title "VANN: A vocabulary for annotating vocabulary descriptions"@en ;
+    vann:preferredNamespacePrefix "vann" ;
+    vann:preferredNamespaceUri "http://purl.org/vocab/vann/" ;
+    a <http://www.w3.org/2002/07/owl#Ontology> .
+
+vann:changes
+    a <http://www.w3.org/2002/07/owl#AnnotationProperty> ;
+    rdfs:comment "A reference to a resource that describes changes between this version of a vocabulary and the previous."@en ;
+    rdfs:isDefinedBy <http://purl.org/vocab/vann/> ;
+    rdfs:label "Changes"@en ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+vann:example
+    a <http://www.w3.org/2002/07/owl#AnnotationProperty> ;
+    rdfs:comment "A reference to a resource that provides an example of how this resource can be used."@en ;
+    rdfs:isDefinedBy <http://purl.org/vocab/vann/> ;
+    rdfs:label "Example"@en ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+vann:preferredNamespacePrefix
+    a <http://www.w3.org/2002/07/owl#AnnotationProperty> ;
+    rdfs:comment "The preferred namespace prefix to use when using terms from this vocabulary in an XML document."@en ;
+    rdfs:isDefinedBy <http://purl.org/vocab/vann/> ;
+    rdfs:label "Preferred Namespace Prefix"@en .
+
+vann:preferredNamespaceUri
+    a <http://www.w3.org/2002/07/owl#AnnotationProperty> ;
+    rdfs:comment "The preferred namespace URI to use when using terms from this vocabulary in an XML document."@en ;
+    rdfs:isDefinedBy <http://purl.org/vocab/vann/> ;
+    rdfs:label "Preferred Namespace Uri"@en .
+
+vann:termGroup
+    a <http://www.w3.org/2002/07/owl#AnnotationProperty> ;
+    rdfs:comment "A group of related terms in a vocabulary."@en ;
+    rdfs:isDefinedBy <http://purl.org/vocab/vann/> ;
+    rdfs:label "Term Group"@en .
+
+vann:usageNote
+    a <http://www.w3.org/2002/07/owl#AnnotationProperty> ;
+    rdfs:comment "A reference to a resource that provides information on how this resource is to be used."@en ;
+    rdfs:isDefinedBy <http://purl.org/vocab/vann/> ;
+    rdfs:label "Usage Note"@en ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+<http://vocab.org/vann/.html>
+    dc:format "text/html" ;
+    a <http://purl.org/dc/dcmitype/Text>, foaf:Document ;
+    rdfs:label "HTML" .
+
+<http://vocab.org/vann/.json>
+    dc:format "application/json" ;
+    a <http://purl.org/dc/dcmitype/Text>, foaf:Document ;
+    rdfs:label "JSON" .
+
+<http://vocab.org/vann/.rdf>
+    dct:hasFormat <http://vocab.org/vann/.html>, <http://vocab.org/vann/.json>, <http://vocab.org/vann/.turtle> ;
+    a <http://purl.org/dc/dcmitype/Text>, foaf:Document ;
+    foaf:primaryTopic <http://purl.org/vocab/vann/> ;
+    foaf:topic <http://purl.org/vocab/vann/> .
+
+<http://vocab.org/vann/.turtle>
+    dc:format "text/plain" ;
+    a <http://purl.org/dc/dcmitype/Text>, foaf:Document ;
+    rdfs:label "Turtle" .
+

--- a/resources/xsd.ttl
+++ b/resources/xsd.ttl
@@ -1,0 +1,221 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix  owl: <http://www.w3.org/2002/07/owl#> .
+
+
+
+xsd: rdfs:label "XSD Namespace Document";
+  <http://purl.org/vocab/vann/preferredNamespaceUri> "http://www.w3.org/2001/XMLSchema#";
+  <http://purl.org/dc/elements/1.1/creator> <http://sebastian.tramp.name>;
+  rdfs:comment """This file is a missing RDF description of the XML Schema datatypes used in RDF/OWL.
+    Please refer to http://www.w3.org/TR/owl-ref/#rdf-datatype for a list of valid datatypes.""" .
+
+xsd:pattern a owl:DatatypeProperty;
+  rdfs:label "patterns" .
+
+xsd:string a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#string>;
+  rdfs:comment "The string datatype represents character strings in XML. The ·value space· of string is the set of finite-length sequences of characters (as defined in [XML 1.0 (Second Edition)]) that ·match· the Char production from [XML 1.0 (Second Edition)]. A character is an atomic unit of communication; it is not further specified except to note that every character has a corresponding Universal Character Set code point, which is an integer.";
+  rdfs:label "string" .
+
+xsd:normalizedString a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#normalizedString>;
+  rdfs:comment "normalizedString represents white space normalized strings. The ·value space· of normalizedString is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters. The ·lexical space· of normalizedString is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters. The ·base type· of normalizedString is string.";
+  rdfs:label "normalizedString" .
+
+xsd:token a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#token>;
+  rdfs:comment "token represents tokenized strings. The ·value space· of token is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters, that have no leading or trailing spaces (#x20) and that have no internal sequences of two or more spaces. The ·lexical space· of token is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters, that have no leading or trailing spaces (#x20) and that have no internal sequences of two or more spaces. The ·base type· of token is normalizedString.";
+  rdfs:label "token" .
+
+xsd:language a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#language>;
+  rdfs:comment "language represents natural language identifiers as defined by by [RFC 3066] . The ·value space· of language is the set of all strings that are valid language identifiers as defined [RFC 3066] . The ·lexical space· of language is the set of all strings that conform to the pattern [a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})* . The ·base type· of language is token.";
+  rdfs:label "language" .
+
+xsd:NMTOKEN a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#NMTOKEN>;
+  rdfs:comment "NMTOKEN represents the NMTOKEN attribute type from [XML 1.0 (Second Edition)]. The ·value space· of NMTOKEN is the set of tokens that ·match· the Nmtoken production in [XML 1.0 (Second Edition)]. The ·lexical space· of NMTOKEN is the set of strings that ·match· the Nmtoken production in [XML 1.0 (Second Edition)]. The ·base type· of NMTOKEN is token.";
+  rdfs:label "NMTOKEN" .
+
+xsd:Name a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#Name>;
+  rdfs:comment "Name represents XML Names. The ·value space· of Name is the set of all strings which ·match· the Name production of [XML 1.0 (Second Edition)]. The ·lexical space· of Name is the set of all strings which ·match· the Name production of [XML 1.0 (Second Edition)]. The ·base type· of Name is token.";
+  rdfs:label "Name" .
+
+xsd:NCName a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#NCName>;
+  rdfs:comment "NCName represents XML 'non-colonized' Names. The ·value space· of NCName is the set of all strings which ·match· the NCName production of [Namespaces in XML]. The ·lexical space· of NCName is the set of all strings which ·match· the NCName production of [Namespaces in XML]. The ·base type· of NCName is Name.";
+  rdfs:label "NCName" .
+
+
+xsd:boolean a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#boolean>;
+  rdfs:comment "An instance of a datatype that is defined as ·boolean· can have the following legal literals {true, false, 1, 0}.";
+  rdfs:label "boolean" .
+
+xsd:decimal a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#decimal>;
+  rdfs:comment "decimal has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39) separated by a period as a decimal indicator. An optional leading sign is allowed. If the sign is omitted, '+' is assumed. Leading and trailing zeroes are optional. If the fractional part is zero, the period and following zeroes can be omitted. For example: -1.23, 12678967.543233, +100000.00, 210.";
+  rdfs:label "decimal" .
+
+xsd:float a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#float>;
+  rdfs:comment "float values have a lexical representation consisting of a mantissa followed, optionally, by the character 'E' or 'e', followed by an exponent. The exponent ·must· be an integer. The mantissa must be a decimal number. The representations for exponent and mantissa must follow the lexical rules for integer and decimal. If the 'E' or 'e' and the following exponent are omitted, an exponent value of 0 is assumed. The special values positive and negative infinity and not-a-number have lexical representations INF, -INF and NaN, respectively. Lexical representations for zero may take a positive or negative sign. For example, -1E4, 1267.43233E12, 12.78e-2, 12 , -0, 0 and INF are all legal literals for float.";
+  rdfs:label "float" .
+
+xsd:double a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#double>;
+  rdfs:comment "double values have a lexical representation consisting of a mantissa followed, optionally, by the character 'E' or 'e', followed by an exponent. The exponent ·must· be an integer. The mantissa must be a decimal number. The representations for exponent and mantissa must follow the lexical rules for integer and decimal. If the 'E' or 'e' and the following exponent are omitted, an exponent value of 0 is assumed. The special values positive and negative infinity and not-a-number have lexical representations INF, -INF and NaN, respectively. Lexical representations for zero may take a positive or negative sign. For example, -1E4, 1267.43233E12, 12.78e-2, 12 , -0, 0 and INF are all legal literals for double.";
+  rdfs:label "double" .
+
+xsd:integer a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#integer>;
+  rdfs:comment "integer has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39) with an optional leading sign. If the sign is omitted, '+' is assumed. For example: -1, 0, 12678967543233, +100000.";
+  rdfs:label "integer" .
+
+xsd:positiveInteger a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#positiveInteger>;
+  rdfs:comment "positiveInteger has a lexical representation consisting of an optional positive sign ('+') followed by a finite-length sequence of decimal digits (#x30-#x39). For example: 1, 12678967543233, +100000.";
+  rdfs:label "positiveInteger" .
+
+xsd:nonPositiveInteger a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#nonPositiveInteger>;
+  rdfs:comment "nonPositiveInteger has a lexical representation consisting of an optional preceding sign followed by a finite-length sequence of decimal digits (#x30-#x39). The sign may be '+' or may be omitted only for lexical forms denoting zero; in all other lexical forms, the negative sign ('-') must be present. For example: -1, 0, -12678967543233, -100000.";
+  rdfs:label "nonPositiveInteger" .
+
+xsd:negativeInteger a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#negativeInteger>;
+  rdfs:comment "negativeInteger has a lexical representation consisting of a negative sign ('-') followed by a finite-length sequence of decimal digits (#x30-#x39). For example: -1, -12678967543233, -100000.";
+  rdfs:label "negativeInteger" .
+
+xsd:nonNegativeInteger a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#nonNegativeInteger>;
+  rdfs:comment "nonNegativeInteger has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, the positive sign ('+') is assumed. If the sign is present, it must be '+' except for lexical forms denoting zero, which may be preceded by a positive ('+') or a negative ('-') sign. For example: 1, 0, 12678967543233, +100000.";
+  rdfs:label "nonNegativeInteger" .
+
+xsd:long a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#long>;
+  rdfs:comment "long is ·derived· from integer by setting the value of ·maxInclusive· to be 9223372036854775807 and ·minInclusive· to be -9223372036854775808. long has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 12678967543233, +100000.";
+  rdfs:label "long" .
+
+xsd:int a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#int>;
+  rdfs:comment "int is ·derived· from long by setting the value of ·maxInclusive· to be 2147483647 and ·minInclusive· to be -2147483648. int has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 126789675, +100000.";
+  rdfs:label "int" .
+
+xsd:short a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#short>;
+  rdfs:comment "short is ·derived· from int by setting the value of ·maxInclusive· to be 32767 and ·minInclusive· to be -32768. short has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 12678, +10000.";
+  rdfs:label "short" .
+
+xsd:byte a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#byte>;
+  rdfs:comment "byte is ·derived· from short by setting the value of ·maxInclusive· to be 127 and ·minInclusive· to be -128. byte has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 126, +100.";
+  rdfs:label "byte" .
+
+xsd:unsignedLong a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#unsignedLong>;
+  rdfs:comment "unsignedLong is ·derived· from nonNegativeInteger by setting the value of ·maxInclusive· to be 18446744073709551615. unsignedLong has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 12678967543233, 100000.";
+  rdfs:label "unsignedLong" .
+
+xsd:unsignedInt a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#unsignedInt>;
+  rdfs:comment "unsignedInt is ·derived· from unsignedLong by setting the value of ·maxInclusive· to be 4294967295. unsignedInt has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 1267896754, 100000.";
+  rdfs:label "unsignedInt" .
+
+xsd:unsignedShort a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#unsignedShort>;
+  rdfs:comment "unsignedShort is ·derived· from unsignedInt by setting the value of ·maxInclusive· to be 65535. unsignedShort has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 12678, 10000.";
+  rdfs:label "unsignedShort" .
+
+xsd:unsignedByte a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#unsignedByte>;
+  rdfs:comment "unsignedByte is ·derived· from unsignedShort by setting the value of ·maxInclusive· to be 255. unsignedByte has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 126, 100.";
+  rdfs:label "unsignedByte" .
+
+
+xsd:dateTime a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#dateTime>;
+  rdfs:comment "The ·lexical space· of dateTime consists of finite-length sequences of characters of the form: '-'? yyyy '-' mm '-' dd 'T' hh ':' mm ':' ss ('.' s+)? (zzzzzz)? For example, 2002-10-10T12:00:00-05:00 (noon on 10 October 2002, Central Daylight Savings Time as well as Eastern Standard Time in the U.S.) is 2002-10-10T17:00:00Z, five hours later than 2002-10-10T12:00:00Z.";
+  rdfs:label "dateTime" .
+
+xsd:dateTimeStamp a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema11-2/#dateTimeStamp> ;
+  rdfs:comment """The lexical space of dateTimeStamp consists of strings which are in the ·lexical space· of dateTime and which also match the regular expression '.*(Z|(\\+|-)[0-9][0-9]:[0-9][0-9])'""" ;
+  rdfs:label "dataTimeStamp" .
+
+xsd:time a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#time>;
+  rdfs:comment "The lexical representation for time is the left truncated lexical representation for dateTime: hh:mm:ss.sss with optional following time zone indicator. For example, to indicate 1:20 pm for Eastern Standard Time which is 5 hours behind Coordinated Universal Time (UTC), one would write: 13:20:00-05:00. See also ISO 8601 Date and Time Formats (·D).";
+  rdfs:label "time" .
+
+xsd:date a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#date>;
+  rdfs:comment "The ·lexical space· of date consists of finite-length sequences of characters of the form: '-'? yyyy '-' mm '-' dd zzzzzz? where the date and optional timezone are represented exactly the same way as they are for dateTime. The first moment of the interval is that represented by: '-' yyyy '-' mm '-' dd 'T00:00:00' zzzzzz? and the least upper bound of the interval is the timeline point represented (noncanonically) by: '-' yyyy '-' mm '-' dd 'T24:00:00' zzzzzz?.";
+  rdfs:label "date" .
+
+xsd:gYearMonth a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#gYearMonth>;
+  rdfs:comment "The lexical representation for gYearMonth is the reduced (right truncated) lexical representation for dateTime: CCYY-MM. No left truncation is allowed. An optional following time zone qualifier is allowed. To accommodate year values outside the range from 0001 to 9999, additional digits can be added to the left of this representation and a preceding '-' sign is allowed. For example, to indicate the month of May 1999, one would write: 1999-05. See also ISO 8601 Date and Time Formats (·D).";
+  rdfs:label "gYearMonth" .
+
+xsd:gYear a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#gYear>;
+  rdfs:comment "The lexical representation for gYear is the reduced (right truncated) lexical representation for dateTime: CCYY. No left truncation is allowed. An optional following time zone qualifier is allowed as for dateTime. To accommodate year values outside the range from 0001 to 9999, additional digits can be added to the left of this representation and a preceding '-' sign is allowed. For example, to indicate 1999, one would write: 1999. See also ISO 8601 Date and Time Formats (·D).";
+  rdfs:label "gYear" .
+
+xsd:gMonthDay a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#gMonthDay>;
+  rdfs:comment "The lexical representation for gMonthDay is the left truncated lexical representation for date: --MM-DD. An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats (·D). This datatype can be used to represent a specific day in a month. To say, for example, that my birthday occurs on the 14th of September ever year.";
+  rdfs:label "gMonthDay" .
+
+xsd:gDay a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#gDay>;
+  rdfs:comment "The lexical representation for gDay is the left truncated lexical representation for date: ---DD . An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats (·D).";
+  rdfs:label "gDay" .
+
+xsd:gMonth a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#gMonth>;
+  rdfs:comment "The lexical representation for gMonth is the left and right truncated lexical representation for date: --MM. An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats (·D).";
+  rdfs:label "gMonth" .
+
+xsd:duration a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#duration>;
+  rdfs:comment "The lexical representation for duration is the [ISO 8601] extended format PnYn MnDTnH nMnS, where nY represents the number of years, nM the number of months, nD the number of days, 'T' is the date/time separator, nH the number of hours, nM the number of minutes and nS the number of seconds. The number of seconds can include decimal digits to arbitrary precision.";
+  rdfs:label "duration" .
+
+xsd:hexBinary a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#hexBinary>;
+  rdfs:comment "hexBinary has a lexical representation where each binary octet is encoded as a character tuple, consisting of two hexadecimal digits ([0-9a-fA-F]) representing the octet code. For example, '0FB7' is a hex encoding for the 16-bit integer 4023 (whose binary representation is 111110110111).";
+  rdfs:label "hexBinary" .
+
+xsd:base64Binary a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#base64Binary>;
+  rdfs:comment "The lexical forms of base64Binary values are limited to the 65 characters of the Base64 Alphabet defined in [RFC 2045], i.e., a-z, A-Z, 0-9, the plus sign (+), the forward slash (/) and the equal sign (=), together with the characters defined in [XML 1.0 (Second Edition)] as white space. No other characters are allowed.";
+  rdfs:label "base64Binary" .
+
+xsd:anyURI a rdfs:Datatype;
+  rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#anyURI>;
+  rdfs:comment "The ·lexical space· of anyURI is finite-length character sequences which, when the algorithm defined in Section 5.4 of [XML Linking Language] is applied to them, result in strings which are legal URIs according to [RFC 2396], as amended by [RFC 2732]. Note:  Spaces are, in principle, allowed in the ·lexical space· of anyURI, however, their use is highly discouraged (unless they are encoded by %20).";
+  rdfs:label "anyURI" .
+
+xsd:maxInclusive a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema-2/#rf-maxInclusive>;
+  rdfs:comment "maxInclusive is the ·inclusive upper bound· of the ·value space· for a datatype with the ·ordered· property. The value of maxInclusive ·must· be in the ·value space· of the ·base type·.";
+  rdfs:label "maxInclusive" .
+
+xsd:maxExclusive a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema-2/#rf-maxExclusive>;
+  rdfs:comment "maxExclusive is the ·exclusive upper bound· of the ·value space· for a datatype with the ·ordered· property. The value of maxExclusive  ·must· be in the ·value space· of the ·base type· or be equal to {value} in {base type definition}.";
+  rdfs:label "maxExclusive".
+
+xsd:minInclusive a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema-2/#rf-minInclusive>;
+  rdfs:comment "minInclusive is the ·inclusive lower bound· of the ·value space· for a datatype with the ·ordered· property. The value of minInclusive  ·must· be in the ·value space· of the ·base type·.";
+  rdfs:label "minInclusive" .
+
+xsd:minExclusive a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema-2/#rf-minExclusive>;
+  rdfs:comment "minExclusive is the ·exclusive lower bound· of the ·value space· for a datatype with the ·ordered· property. The value of minExclusive ·must· be in the ·value space· of the ·base type· or be equal to {value} in {base type definition}.";
+  rdfs:label "minExclusive" .

--- a/src/Data/RDF/Vocabulary/DCTerms.hs
+++ b/src/Data/RDF/Vocabulary/DCTerms.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module Data.RDF.Vocabulary.DCTerms where
+
+import qualified Data.RDF.Namespace (mkPrefixedNS)
+import qualified Data.RDF.Types (unode)
+import Data.RDF.Vocabulary.Generator.VocabularyGenerator (genVocabulary)
+import qualified Data.Text (pack)
+
+$(genVocabulary "resources/dcterms.ttl")

--- a/src/Data/RDF/Vocabulary/FOAF.hs
+++ b/src/Data/RDF/Vocabulary/FOAF.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module Data.RDF.Vocabulary.FOAF where
+
+import qualified Data.RDF.Namespace (mkPrefixedNS)
+import qualified Data.RDF.Types (unode)
+import Data.RDF.Vocabulary.Generator.VocabularyGenerator (genVocabulary)
+import qualified Data.Text (pack)
+
+$(genVocabulary "resources/foaf.ttl")

--- a/src/Data/RDF/Vocabulary/Generator/VocabularyGenerator.hs
+++ b/src/Data/RDF/Vocabulary/Generator/VocabularyGenerator.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Data.RDF.Vocabulary.Generator.VocabularyGenerator
+  ( genVocabulary,
+  )
+where
+
+import Data.Char (isLower)
+import Data.List (nub)
+import qualified Data.Map as M
+import Data.Maybe (maybeToList)
+import Data.RDF
+  ( AdjHashMap,
+    Node (UNode),
+    PrefixMappings (PrefixMappings),
+    RDF,
+    Rdf,
+    TurtleParser (TurtleParser),
+    parseFile,
+    prefixMappings,
+    subjectOf,
+    triplesOf,
+  )
+import Data.Text (Text)
+import qualified Data.Text as T
+import Language.Haskell.TH
+
+-- | Generates 'Node' values for concepts and properties, and
+-- 'Namespace' values, for a given schema in the Haskell module in
+-- which 'genVocabulary' is used.
+--
+-- Concepts in the schema are prepended with "_", the names of
+-- properties are unchanged.
+--
+-- For example:
+--
+-- >>> $(genVocabulary "resources/shacl.ttl")
+--
+-- creates many 'Node' values including
+--
+-- @
+--     _SPARQLConstraint  :: Node
+--     annotationProperty :: Node
+-- @
+--
+-- This is used to auto-generate all modules in Data.RDF.Vocabulary.* at
+-- compile time with Template Haskell.
+genVocabulary ::
+  -- | the filepath of the file containing the schema in RDF Turtle format.
+  String ->
+  Q [Dec]
+genVocabulary file = vocabulary <$> runIO (loadGraph file)
+
+loadGraph :: String -> IO (RDF AdjHashMap)
+loadGraph file =
+  parseFile (TurtleParser Nothing Nothing) file >>= \result -> case result of
+    Left err -> error $ show err
+    Right rdfGraph -> return rdfGraph
+
+vocabulary :: Rdf a => RDF a -> [Dec]
+vocabulary graph =
+  let nameDecls = do
+        subject <- nub $ subjectOf <$> triplesOf graph
+        iri <- maybeToList $ toIRI subject
+        name <- maybeToList $ iriToName iri
+        return (name, declareIRI name iri)
+      (PrefixMappings prefixMappings') = prefixMappings graph
+      namespaceDecls = do
+        (prefix, iri) <- M.toList prefixMappings'
+        let name = mkName . T.unpack . escape $ prefix <> "NS"
+        return $ declarePrefix name prefix iri
+      iriDecls = snd <$> nameDecls
+      irisDecl = declareIRIs $ fst <$> nameDecls
+   in irisDecl : namespaceDecls <> iriDecls
+
+toIRI :: Node -> Maybe Text
+toIRI (UNode iri) = Just iri
+toIRI _ = Nothing
+
+packFun :: Exp
+packFun = VarE $ mkName "Data.Text.pack"
+
+unodeFun :: Exp
+unodeFun = VarE $ mkName "Data.RDF.Types.unode"
+
+mkPrefixedNSFun :: Exp
+mkPrefixedNSFun = VarE $ mkName "Data.RDF.Namespace.mkPrefixedNS"
+
+declareIRI :: Name -> Text -> Dec
+declareIRI name iri =
+  let iriLiteral = LitE . StringL $ T.unpack iri
+      unodeLiteral = AppE unodeFun $ AppE packFun iriLiteral
+   in FunD name [Clause [] (NormalB unodeLiteral) []]
+
+declareIRIs :: [Name] -> Dec
+declareIRIs names =
+  let iriList = ListE (VarE <$> names)
+   in FunD (mkName "iris") [Clause [] (NormalB iriList) []]
+
+-- namespace = mkPrefixedNS "ogit" "http://www.purl.org/ogit/"
+declarePrefix :: Name -> Text -> Text -> Dec
+declarePrefix name prefix iri =
+  let prefixLiteral = AppE packFun . LitE . StringL . T.unpack $ prefix
+      iriLiteral = AppE packFun . LitE . StringL . T.unpack $ iri
+      namespace = AppE (AppE mkPrefixedNSFun prefixLiteral) iriLiteral
+   in FunD name [Clause [] (NormalB namespace) []]
+
+iriToName :: Text -> Maybe Name
+iriToName iri = mkName . T.unpack . escape <$> (lastMay . filter (not . T.null) . T.split (`elem` separators)) iri
+  where
+    separators = ['/', '#']
+    lastMay :: [a] -> Maybe a
+    lastMay [] = Nothing
+    lastMay xs = Just (last xs)
+
+escape :: Text -> Text
+escape name = escapeKeywords $ T.map escapeOperators name
+  where
+    escapeOperators c | c `elem` operators = escapeChar
+    escapeOperators c = c
+    escapeKeywords name' | not (isLower $ T.head name') = escapeChar `T.cons` name'
+    escapeKeywords name' | name' `elem` keywords = escapeChar `T.cons` name'
+    escapeKeywords name' = name'
+    operators = ['!', '#', '$', '%', '&', '*', '+', '.', '/', '<', '=', '>', '?', '@', '\\', '^', '|', '-', '~']
+    keywords =
+      [ "as",
+        "case",
+        "of",
+        "class",
+        "data",
+        "data family",
+        "data instance",
+        "default",
+        "deriving",
+        "deriving instance",
+        "do",
+        "forall",
+        "foreign",
+        "hiding",
+        "if",
+        "then",
+        "else",
+        "import",
+        "infix",
+        "infixl",
+        "infixr",
+        "instance",
+        "let",
+        "in",
+        "mdo",
+        "module",
+        "newtype",
+        "proc",
+        "qualified",
+        "rec",
+        "type",
+        "type family",
+        "type instance",
+        "where"
+      ]
+    escapeChar = '_'

--- a/src/Data/RDF/Vocabulary/OWL.hs
+++ b/src/Data/RDF/Vocabulary/OWL.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module Data.RDF.Vocabulary.OWL where
+
+import qualified Data.RDF.Namespace (mkPrefixedNS)
+import qualified Data.RDF.Types (unode)
+import Data.RDF.Vocabulary.Generator.VocabularyGenerator (genVocabulary)
+import qualified Data.Text (pack)
+
+$(genVocabulary "resources/owl.ttl")

--- a/src/Data/RDF/Vocabulary/RDF.hs
+++ b/src/Data/RDF/Vocabulary/RDF.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module Data.RDF.Vocabulary.RDF where
+
+import qualified Data.RDF.Namespace (mkPrefixedNS)
+import qualified Data.RDF.Types (unode)
+import Data.RDF.Vocabulary.Generator.VocabularyGenerator (genVocabulary)
+import qualified Data.Text (pack)
+
+$(genVocabulary "resources/rdf.ttl")

--- a/src/Data/RDF/Vocabulary/RDFS.hs
+++ b/src/Data/RDF/Vocabulary/RDFS.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module Data.RDF.Vocabulary.RDFS where
+
+import qualified Data.RDF.Namespace (mkPrefixedNS)
+import qualified Data.RDF.Types (unode)
+import Data.RDF.Vocabulary.Generator.VocabularyGenerator (genVocabulary)
+import qualified Data.Text (pack)
+
+$(genVocabulary "resources/rdfs.ttl")

--- a/src/Data/RDF/Vocabulary/SHACL.hs
+++ b/src/Data/RDF/Vocabulary/SHACL.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module Data.RDF.Vocabulary.SHACL where
+
+import qualified Data.RDF.Namespace (mkPrefixedNS)
+import qualified Data.RDF.Types (unode)
+import Data.RDF.Vocabulary.Generator.VocabularyGenerator (genVocabulary)
+import qualified Data.Text (pack)
+
+$(genVocabulary "resources/shacl.ttl")

--- a/src/Data/RDF/Vocabulary/SKOS.hs
+++ b/src/Data/RDF/Vocabulary/SKOS.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module Data.RDF.Vocabulary.SKOS where
+
+import qualified Data.RDF.Namespace (mkPrefixedNS)
+import qualified Data.RDF.Types (unode)
+import Data.RDF.Vocabulary.Generator.VocabularyGenerator (genVocabulary)
+import qualified Data.Text (pack)
+
+$(genVocabulary "resources/skos.ttl")

--- a/src/Data/RDF/Vocabulary/VANN.hs
+++ b/src/Data/RDF/Vocabulary/VANN.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module Data.RDF.Vocabulary.VANN where
+
+import qualified Data.RDF.Namespace (mkPrefixedNS)
+import qualified Data.RDF.Types (unode)
+import Data.RDF.Vocabulary.Generator.VocabularyGenerator (genVocabulary)
+import qualified Data.Text (pack)
+
+$(genVocabulary "resources/vann.ttl")

--- a/src/Data/RDF/Vocabulary/XSD.hs
+++ b/src/Data/RDF/Vocabulary/XSD.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module Data.RDF.Vocabulary.XSD where
+
+import qualified Data.RDF.Namespace (mkPrefixedNS)
+import qualified Data.RDF.Types (unode)
+import Data.RDF.Vocabulary.Generator.VocabularyGenerator (genVocabulary)
+import qualified Data.Text (pack)
+
+$(genVocabulary "resources/xsd.ttl")


### PR DESCRIPTION
Adds `Data.RDF.Vocabulary.Generator.VocabularyGenerator`, which provides the `genVocabulary` function. This function uses Template Haskell to create a Haskell module from a schema in a Turtle file, at compile time.

This Pull Request also adds nine schema modules to this library, using the `genVocabulary` function:

1. DCTerms
2. OWL
3. RDF
4. XSD
5. VANN
6. SHACL
7. RDFS
8. FOAF
9. SKOS

Based on @fabianmeyer 's [rdf4h-vocabulary-generator](https://github.com/fabianmeyer/rdf4h-vocabulary-generator) and [rdf4h-vocabulary](https://github.com/fabianmeyer/rdf4h-vocabulary) packages, bringing this functionality upstream into the `rdf4h` library.