### PR TITLE
Use `rdfs:comment` string to generate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For details see the GitHub project page:
 
 http://robstewart57.github.io/rdf4h/
 
-Supports GHC versions from 8.0.2 (stackage lts-9) to 8.8.3 (stackage lts-16.0).
+Supports GHC versions from 9.2.5 (stackage lts-20.11).
 
 ### Development with Nix and direnv
 

--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -21,7 +21,7 @@ cabal-version:   >= 1.10
 build-type:      Simple
 category:        RDF
 stability:       stable
-tested-with:     GHC==8.0.2, GHC==8.2.2, GHC==8.4.3, GHC==8.6.5, GHC==8.8.3
+tested-with:     GHC==9.2.5
 extra-tmp-files: test
 extra-source-files: examples/ParseURLs.hs
                   , examples/ESWC.hs
@@ -97,7 +97,7 @@ library
                  , selective
                  , html-entities
                  , xeno
-                 , template-haskell
+                 , template-haskell >= 2.18.0
   other-modules:   Text.RDF.RDF4H.XmlParser.Xmlbf
                  , Text.RDF.RDF4H.XmlParser.Xeno
   if impl(ghc < 7.6)

--- a/src/Data/RDF/Vocabulary/Generator/VocabularyGenerator.hs
+++ b/src/Data/RDF/Vocabulary/Generator/VocabularyGenerator.hs
@@ -96,7 +96,9 @@ declareIRI name iri =
 declareIRIs :: [Name] -> Q Dec
 declareIRIs names =
   let iriList = ListE (VarE <$> names)
-   in funD (mkName "iris") [return $ Clause [] (NormalB iriList) []]
+   in funD_doc (mkName "iris") [return $ Clause [] (NormalB iriList) []]
+               (Just $ "All IRIs in this vocabulary.")
+               [Nothing]
 
 -- namespace = mkPrefixedNS "ogit" "http://www.purl.org/ogit/"
 declarePrefix :: Name -> Text -> Text -> Q Dec

--- a/src/Data/RDF/Vocabulary/Generator/VocabularyGenerator.hs
+++ b/src/Data/RDF/Vocabulary/Generator/VocabularyGenerator.hs
@@ -8,7 +8,7 @@ where
 
 import Control.Monad (join)
 import Data.Char (isLower)
-import Data.List (nub)
+import Data.List (nub, sortBy)
 import qualified Data.Map as M
 import Data.Maybe (maybeToList)
 import Data.RDF
@@ -78,7 +78,7 @@ vocabulary graph =
         (prefix, iri) <- M.toList prefixMappings'
         let name = mkName . T.unpack . escape $ prefix <> "NS"
         return $ declarePrefix name prefix iri
-      iriDecls = snd <$> nameDecls
+      iriDecls = fmap snd . sortBy (\x y -> fst y `compare` fst x) $ nameDecls
       irisDecl = declareIRIs $ fst <$> nameDecls
    in sequence $ irisDecl : namespaceDecls <> iriDecls
 

--- a/src/Data/RDF/Vocabulary/Generator/VocabularyGenerator.hs
+++ b/src/Data/RDF/Vocabulary/Generator/VocabularyGenerator.hs
@@ -104,7 +104,9 @@ declarePrefix name prefix iri =
   let prefixLiteral = AppE packFun . LitE . StringL . T.unpack $ prefix
       iriLiteral = AppE packFun . LitE . StringL . T.unpack $ iri
       namespace = AppE (AppE mkPrefixedNSFun prefixLiteral) iriLiteral
-   in funD name [return $ Clause [] (NormalB namespace) []]
+   in funD_doc name [return $ Clause [] (NormalB namespace) []]
+               (Just $ "Namespace prefix for \\<<" <> T.unpack iri <> ">\\>.")
+               [Nothing]
 
 iriToName :: Text -> Maybe Name
 iriToName iri = mkName . T.unpack . escape <$> (lastMay . filter (not . T.null) . T.split (`elem` separators)) iri

--- a/src/Data/RDF/Vocabulary/Generator/VocabularyGenerator.hs
+++ b/src/Data/RDF/Vocabulary/Generator/VocabularyGenerator.hs
@@ -64,7 +64,7 @@ vocabulary graph =
         subject <- nub $ subjectOf <$> triplesOf graph
         iri <- maybeToList $ toIRI subject
         name <- maybeToList $ iriToName iri
-        return (name, declareIRI name iri)
+        return (name, declareIRI name iri Nothing)
       (PrefixMappings prefixMappings') = prefixMappings graph
       namespaceDecls = do
         (prefix, iri) <- M.toList prefixMappings'
@@ -87,11 +87,13 @@ unodeFun = VarE $ mkName "Data.RDF.Types.unode"
 mkPrefixedNSFun :: Exp
 mkPrefixedNSFun = VarE $ mkName "Data.RDF.Namespace.mkPrefixedNS"
 
-declareIRI :: Name -> Text -> Q Dec
-declareIRI name iri =
+declareIRI :: Name -> Text -> Maybe Text -> Q Dec
+declareIRI name iri comment =
   let iriLiteral = LitE . StringL $ T.unpack iri
       unodeLiteral = AppE unodeFun $ AppE packFun iriLiteral
-   in funD name [return $ Clause [] (NormalB unodeLiteral) []]
+   in funD_doc name [return $ Clause [] (NormalB unodeLiteral) []]
+               (T.unpack <$> comment)
+               [Nothing]
 
 declareIRIs :: [Name] -> Q Dec
 declareIRIs names =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,18 +1,7 @@
-resolver: lts-16.6
+resolver: lts-20.11
 packages:
 - '.'
 extra-deps:
-- algebraic-graphs-0.5
-- unordered-containers-0.2.10.0
-- selective-0.3
-- html-entities-1.1.4.3
-- mmorph-1.1.3
-- exceptions-0.10.4
-- semigroups-0.18.3
-- xeno-0.3.5.2
-- Cabal-3.2.0.0@sha256:d0d7a1f405f25d0000f5ddef684838bc264842304fd4e7f80ca92b997b710874,27320
-- parsec-3.1.14.0
-- text-1.2.4.0
 
 # for weeder tool
 #   https://github.com/ndmitchell/weeder


### PR DESCRIPTION
This pull request teaches the `Data.RDF.Vocabulary.Generator.VocabularyGenerator` module to use `rdfs:comment` predicates in the input RDFS or OWL file to document the generated Haskell `Node`s.  Please see each commit message for discussion about the decisions made for the changes.

There are two decisions that should be called out explicitly, though:

  1. Patch bd44a8c bumps the Stackage LTS version to the minimum one that supports Template Haskell 2.18.0, which introduces the ability to attach Haddock documentation to generated declarations.  I tried explicitly pinning this version of Template Haskell in the `stack.yaml` file, but several packages incorrectly list Template Haskell `2.17` as their upper bound, meaning this solution requires also pinning most of our direct dependencies' versions in `stack.yaml` as well.  Given that the Stackage LTS the package depends on is several years old at this point, I chose to bump the LTS version we test with.
  2. Patch c99e94b sorts the generated `Node`s alphabetically, which has the nice side effect of putting all classes first, and all predicates after.  The previous behavior seems to be to generate the declarations in the reverse order that they appear in the input RDFS or OWL file.  On one hand, the current behavior seems wrong; on the other, if the input RDFS or OWL file's order matters, this is lost in the generated output.  For me as a user, I would ideally like predicates, classes, namespaces, and `iris` separated into different sections in the Haddock documentation, regardless of what order they appear in the input, but this would involve a more invasive change to the API of the `VocabularyGenerator` module than this pull request endeavored to undertake.  I have kept this as a separate patch in case this change is not desired.

Fixes #109.